### PR TITLE
cli.py: fix the bug of extract_src command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -256,6 +256,7 @@ if __name__ == '__main__':
 
         rpmbuild_root = mkdtemp()
         sh.rpmbuild('--define', '%%_topdir %s' % rpmbuild_root,
+                    '--define', '%%__python %s' % '/usr/bin/python2',
                     '-rp', '--nodeps', kernel_src_rpm)
 
         src = glob('kernel*/linux*', rpmbuild_root + '/BUILD/')

--- a/cli.py
+++ b/cli.py
@@ -256,7 +256,7 @@ if __name__ == '__main__':
 
         rpmbuild_root = mkdtemp()
         sh.rpmbuild('--define', '%%_topdir %s' % rpmbuild_root,
-                    '-rp', kernel_src_rpm)
+                    '-rp', '--nodeps', kernel_src_rpm)
 
         src = glob('kernel*/linux*', rpmbuild_root + '/BUILD/')
 


### PR DESCRIPTION
It is not necessary to verify build dependencies for extracting src, and python2 and python3 are distinguished in anolis OS, so we need to specify the python version.