### PR TITLE
contrib: Fix two bugs in Dockerfile when working with Anolis OS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN pip install --upgrade setuptools && \
 		elfutils-devel-static \
 		glibc-static zlib-static \
 		libstdc++-static \
-		gcc-python-plugin \
     		rpm-build rsync bc perl -y && \
+    yum install gcc-python-plugin --enablerepo=Plus -y && \
     yum clean all
 
 COPY . /usr/local/lib/plugsched/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 From openanolis/anolisos:8.4-x86_64
 
-RUN yum install python2 gcc gcc-c++ wget -y && \
+RUN yum install python2 gcc gcc-c++ wget libyaml-devel -y && \
     wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
     python2 get-pip.py
 RUN pip install --upgrade setuptools && \
-    pip install six pyyaml sh coloredlogs future fire jinja2 docopt && \
+    pip install --global-option='--with-libyaml' pyyaml && \
+    pip install six sh coloredlogs future fire jinja2 docopt && \
     yum install make bison flex \
 		gcc-plugin-devel.x86_64 python2-devel \
 		elfutils-libelf-devel.x86_64 openssl openssl-devel \


### PR DESCRIPTION
Choose "Plus" yum repo for gcc-python-plugin, which is disabled by default
in Anolis OS.

Force compile pyyaml with libyaml-devel, otherwise we can't import CLoader.