### PR TITLE
contrib: install python2-devel before compiling pyyaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 From openanolis/anolisos:8.4-x86_64
 
-RUN yum install python2 gcc gcc-c++ wget libyaml-devel -y && \
+RUN yum install python2 python2-devel gcc gcc-c++ wget libyaml-devel -y && \
     wget https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
     python2 get-pip.py
 RUN pip install --upgrade setuptools && \
     pip install --global-option='--with-libyaml' pyyaml && \
     pip install six sh coloredlogs future fire jinja2 docopt && \
     yum install make bison flex \
-		gcc-plugin-devel.x86_64 python2-devel \
+		gcc-plugin-devel.x86_64 \
 		elfutils-libelf-devel.x86_64 openssl openssl-devel \
 		elfutils-devel-static \
 		glibc-static zlib-static \


### PR DESCRIPTION
Compiling pyyaml requires python2-devel

Fixes: eb100b36ef50 ("contrib: force compile pyyaml with libyaml-devel")
Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>