### PR TITLE
docs: delete LICENSE 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,0 @@
-This software is made available under the terms of *either* of the licenses
-found in LICENSE.GPLv2 or LICENSE.BSD. Contributions to plugsched are made
-under the terms of *both* these licenses.


### PR DESCRIPTION
This file is unimportant, as long as we have LICENSE.BSD and LICENSE.GPLv2.
Remove it so Github can correctly identify only these two LICENSE files,
rather than one more unknown LICENSE file.