### PR TITLE
src: add SPDX information

### DIFF
--- a/tests/test_cpu_throttle/assert
+++ b/tests/test_cpu_throttle/assert
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright 2019-2022 Alibaba Group Holding Limited.
+# SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 
 import subprocess
 import sh

--- a/tests/test_domain_rebuild/assert
+++ b/tests/test_domain_rebuild/assert
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright 2019-2022 Alibaba Group Holding Limited.
+# SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 
 import os
 import sh

--- a/tests/test_public_var/assert
+++ b/tests/test_public_var/assert
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright 2019-2022 Alibaba Group Holding Limited.
+# SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 
 import subprocess
 import sh

--- a/tests/test_sched_syscall/assert
+++ b/tests/test_sched_syscall/assert
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright 2019-2022 Alibaba Group Holding Limited.
+# SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 
 import subprocess
 import sys

--- a/tests/test_var_uniformity/assert
+++ b/tests/test_var_uniformity/assert
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# Copyright 2019-2022 Alibaba Group Holding Limited.
+# SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 
 from typing import Dict
 import sh


### PR DESCRIPTION
Add SPDX information for tests:

1. test_cpu_throttle

2. test_domain_rebuild

3. test_public_var

4. test_sched_syscall

5. test_var_uniformity

Signed-off-by: Xuchun Shang <xuchun.shang@linux.alibaba.com>