### PR TITLE
src: rename bsearch to func_addr_bsearch

### DIFF
--- a/src/helper.h
+++ b/src/helper.h
@@ -31,7 +31,7 @@ static inline void set_value_long(unsigned long addr, unsigned long val)
 /*
  * binary search method
  */
-int bsearch(unsigned long *arr, int start, int end, unsigned long tar)
+int func_addr_bsearch(unsigned long *arr, int start, int end, unsigned long tar)
 {
 	int mid;
 

--- a/src/stack_check.h
+++ b/src/stack_check.h
@@ -62,7 +62,7 @@ static int stack_check_fn(unsigned long *entries, unsigned int nr_entries, bool 
 		int idx;
 		unsigned long address = entries[i];
 
-		idx = bsearch(func_addr, 0, NR_INTERFACE_FN - 1, address);
+		idx = func_addr_bsearch(func_addr, 0, NR_INTERFACE_FN - 1, address);
 		if (idx == -1)
 			return 0;
 		if (address < func_addr[idx] + func_size[idx])


### PR DESCRIPTION
The function name "bsearch" in helper.h would conflict with the function
which has the same name in lib/bsearch.c. When the compiler check is
weak, helper.h would replace lib/bsearch.c all the time, which is not
expected for kernel source code.

Rename the function in helper.h to func_addr_bsearch to avoid conflicts.

Signed-off-by: Tianchen Ding <dtcccc@linux.alibaba.com>