### PR TITLE
src: make functions and variables in headers static

### DIFF
--- a/src/helper.h
+++ b/src/helper.h
@@ -31,7 +31,7 @@ static inline void set_value_long(unsigned long addr, unsigned long val)
 /*
  * binary search method
  */
-int bsearch(unsigned long *arr, int start, int end, unsigned long tar)
+static int bsearch(unsigned long *arr, int start, int end, unsigned long tar)
 {
 	int mid;
 
@@ -67,7 +67,7 @@ static inline void addr_swap(unsigned long *a, unsigned long *b)
 /*
  * This sort method is coming from lib/sort.c
  */
-void addr_sort(unsigned long *addr, unsigned long *size, int n) {
+static void addr_sort(unsigned long *addr, unsigned long *size, int n) {
 	int i = n/2 - 1, c, r;
 
 	for ( ; i >= 0; i -= 1) {

--- a/src/mempool.h
+++ b/src/mempool.h
@@ -165,14 +165,14 @@ static inline bool is_simple_percpu_mempool_addr(
 #define FIELD_INDIRECT_TYPE(t, f) typeof(*((struct t*)0)->f)
 
 #define DEFINE_RESERVE(type, field, name, require, max)			\
-struct simple_mempool *name##_smp = NULL;				\
-void release_##name##_reserve(struct type *x)				\
+static struct simple_mempool *name##_smp = NULL;			\
+static void release_##name##_reserve(struct type *x)			\
 {									\
 	if (!is_simple_mempool_addr(name##_smp, x->field))		\
 		kfree(x->field);					\
 	x->field = NULL;						\
 }									\
-FIELD_TYPE(type, field) alloc_##name##_reserve(void)			\
+static IELD_TYPE(type, field) alloc_##name##_reserve(void)		\
 {									\
 	return simple_mempool_alloc(name##_smp);			\
 }									\
@@ -192,14 +192,14 @@ static int recheck_mempool_##name(void)					\
 }
 
 #define DEFINE_RESERVE_PERCPU(type, field, name, require, max)		\
-struct simple_percpu_mempool *name##_smp = NULL;			\
-void release_##name##_reserve(struct type *x)				\
+static struct simple_percpu_mempool *name##_smp = NULL;			\
+static void release_##name##_reserve(struct type *x)			\
 {									\
 	if (!is_simple_percpu_mempool_addr(name##_smp, x->field))	\
 		free_percpu((void *)x->field);				\
 	x->field = NULL;						\
 }									\
-FIELD_TYPE(type, field) alloc_##name##_reserve(void)			\
+static FIELD_TYPE(type, field) alloc_##name##_reserve(void)		\
 {									\
 	return simple_percpu_mempool_alloc(name##_smp);			\
 }									\


### PR DESCRIPTION
Functions and variables in headers of /src are only used by plugsched
itself, so they should be static, to avoid conflicts with kernel source
code. (e.g. bsearch)

Signed-off-by: Tianchen Ding <dtcccc@linux.alibaba.com>