### PR TITLE
contrib: migrate anolis base docker image from 8.4 to 8.6

### DIFF
--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -1,6 +1,6 @@
 # Copyright 2019-2022 Alibaba Group Holding Limited.
 # SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
-From openanolis/anolisos:8.4-x86_64
+From openanolis/anolisos:8.6-x86_64
 
 RUN yum install python3 python3-devel python3-lxml gcc gcc-c++ wget libyaml-devel -y && \
     yum install python3-pip -y


### PR DESCRIPTION
Because the gcc-python-plugin-0.17-1.2 package is built in anolis
8.6 and the yum Plus repo is shared between 8.6 and 8.4, the
gcc-python-plugin-0.17-1.2 can not work in anolis8.4. And the Anolis8.4
is no longer maintained, so I migrate the base docker image from 8.4 to
8.6 and the new docker image will be rolled out at next release.

I have tested the plugsched in the new docker image which can not afect
the exist system.

Signed-off-by: Erwei Deng <erwei@linux.alibaba.com>