### PR TITLE
src: Place init functions into .init.text section

### DIFF
--- a/src/scheduler.lds
+++ b/src/scheduler.lds
@@ -9,5 +9,6 @@
 SECTIONS {
 	PROVIDE(__mod_sched_start = .);
 	.sched.text		0 : ALIGN(8) { *(.sched.text) }
+	.init.text		0 : ALIGN(8) { *(.init.text) *(.ref.text) }
 	PROVIDE(__mod_sched_end = .);
 }


### PR DESCRIPTION
We determine whether a function is an init function by whether it
is defined in the .init.text section. But there are some init
functions are placed in .ref.text section, and we put them into
.init.text at the linking stage.

Signed-off-by: Cruz Zhao <CruzZhao@linux.alibaba.com>