### PR TITLE
remove frame pointer register for stack balancing for x86

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -76,15 +76,16 @@ class Plugsched(object):
         with open(os.path.join(self.config_dir, 'boundary.yaml')) as f:
             self.config = load(f, Loader)
         self.file_mapping = {
-            self.config_dir + '/*':     self.tmp_dir,
-            'boundary/*.py':            self.tmp_dir,
-            'tools/symbol_resolve':     self.tmp_dir,
-            'src/sidecar.py':           self.tmp_dir,
-            'src/Makefile.plugsched':   self.tmp_dir,
-            'src/*.[ch]':               self.mod_path,
-            'src/Makefile':             self.mod_path,
-            'src/scheduler.lds':        self.mod_path,
-            'src/.gitignore':           './',
+            self.config_dir + '/*':         self.tmp_dir,
+            'boundary/*.py':                self.tmp_dir,
+            'tools/symbol_resolve':         self.tmp_dir,
+            'tools/springboard_search.sh':  self.tmp_dir,
+            'src/sidecar.py':               self.tmp_dir,
+            'src/Makefile.plugsched':       self.tmp_dir,
+            'src/*.[ch]':                   self.mod_path,
+            'src/Makefile':                 self.mod_path,
+            'src/scheduler.lds':            self.mod_path,
+            'src/.gitignore':               './',
         }
         self.threads = cpu_count()
         self.mod_files = self.config['mod_files']
@@ -207,7 +208,7 @@ class Plugsched(object):
             self.apply_patch('dynamic_springboard.patch')
 
         with open(os.path.join(self.mod_path, 'Makefile'), 'a') as f:
-            self.search_springboard(self.vmlinux, kernel_config, _out=f)
+            self.search_springboard('init', self.vmlinux, kernel_config, _out=f)
 
         logging.info("Succeed!")
 

--- a/configs/4.19/dynamic_springboard.patch
+++ b/configs/4.19/dynamic_springboard.patch
@@ -26,19 +26,18 @@ index 5ec2ca5..3b8925a 100644
  static __always_inline struct rq *
  context_switch(struct rq *rq, struct task_struct *prev,
  	       struct task_struct *next, struct rq_flags *rf)
-@@ -2634,7 +2636,44 @@ context_switch(struct rq *rq, struct task_struct *prev,
+@@ -2634,7 +2636,43 @@ context_switch(struct rq *rq, struct task_struct *prev,
  	prepare_lock_switch(rq, next, rf);
  
  	/* Here we just switch the register state and the stack. */
 -	switch_to(prev, next, prev);
 +#ifdef CONFIG_X86_64
 +	prepare_switch_to(next);
-+	__asm__("mov %%rbp,%%rsp\n\t"
-+		"sub %0,%%rsp\n\t"
++	__asm__("add %0,%%rsp\n\t"
 +		"pushq %1\n\t"
 +		"jmp __switch_to_asm"
 +		:
-+		:"i"(STACKSIZE_VMLINUX + 0x28), "r"(sched_springboard), "D"(prev), "S"(next)
++		:"i"(STACKSIZE_MOD - STACKSIZE_VMLINUX), "r"(sched_springboard), "D"(prev), "S"(next)
 +		:"rbx","r12","r13","r14","r15"
 +	);
 +#endif

--- a/configs/4.19/dynamic_springboard.patch
+++ b/configs/4.19/dynamic_springboard.patch
@@ -38,7 +38,7 @@ index 5ec2ca5..3b8925a 100644
 +		"pushq %1\n\t"
 +		"jmp __switch_to_asm"
 +		:
-+		:"i"(STACKSIZE_SCHEDULE + 0x28), "r"(sched_springboard), "D"(prev), "S"(next)
++		:"i"(STACKSIZE_VMLINUX + 0x28), "r"(sched_springboard), "D"(prev), "S"(next)
 +		:"rbx","r12","r13","r14","r15"
 +	);
 +#endif
@@ -62,7 +62,7 @@ index 5ec2ca5..3b8925a 100644
 +		"ldr x30,%1\n\t"
 +		"b __switch_to"
 +		:
-+		:"i"(STACKSIZE_SCHEDULE), "m"(sched_springboard),"r"(prev),"r"(next)
++		:"i"(STACKSIZE_VMLINUX), "m"(sched_springboard),"r"(prev),"r"(next)
 +		:"x19","x20","x21","x22","x23","x24","x25",
 +		 "x26","x27","x28","x30","x0","x1"
 +	);

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,7 @@ objs-$(CONFIG_SCHED_DEBUG) += debug.o
 
 obj-m += scheduler.o
 
-CFLAGS_core.stub.o := -DSTACKSIZE_MOD=0
+CFLAGS_core.stub.o := -DMODULE -DSTACKSIZE_MOD=0
 $(obj)/core.stub.o: $(src)/core.c FORCE
 	$(call cmd,force_checksrc)
 	$(call if_changed_rule,cc_o_c)
@@ -44,3 +44,4 @@ scheduler-objs := $(objs-y) main.o sched_rebuild.o
 ldflags-y += -T $(plugsched_modpath)/scheduler.lds
 ccflags-n += -DSCHEDMOD_MEMPOOL
 ccflags-y += -Wno-unused-function
+ccflags-y += -fkeep-static-functions

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,15 @@ objs-$(CONFIG_SCHED_DEBUG) += debug.o
 
 obj-m += scheduler.o
 
-$(obj)/%.o: $(src)/%.c FORCE
+CFLAGS_core.stub.o := -DSTACKSIZE_MOD=0
+$(obj)/core.stub.o: $(src)/core.c FORCE
+	$(call cmd,force_checksrc)
+	$(call if_changed_rule,cc_o_c)
+
+GET_STACK_SIZE: $(obj)/core.stub.o
+	$(eval CFLAGS_core.o += -DSTACKSIZE_MOD=$(shell bash $(plugsched_tmpdir)/springboard_search.sh build $<))
+
+$(obj)/%.o: $(src)/%.c GET_STACK_SIZE FORCE
 	$(call cmd,force_checksrc)
 	$(call if_changed_rule,cc_o_c)
 	$(OBJCOPY) $(OBJCOPYFLAGS) $(OBJCOPYFLAGS_$(@F)) $@

--- a/src/Makefile.plugsched
+++ b/src/Makefile.plugsched
@@ -11,7 +11,7 @@ GCC_PLUGIN_FLAGS := -fplugin=/usr/lib64/gcc-python-plugin/python.so \
 PHONY += plugsched sidecar collect extract
 
 plugsched: scripts prepare sidecar
-	$(MAKE) CFLAGS_MODULE=-fkeep-static-functions -C $(srctree) M=$(plugsched_modpath) modules
+	$(MAKE) -C $(srctree) M=$(plugsched_modpath) modules
 
 sidecar: $(plugsched_modpath)/export_jump_sidecar.h
 	python3 $(plugsched_tmpdir)/sidecar.py $< ./vmlinux $(plugsched_tmpdir) $(plugsched_modpath)

--- a/tools/springboard_search.sh
+++ b/tools/springboard_search.sh
@@ -103,7 +103,7 @@ function get_stack_check_off_AArch64()
 function output()
 {
 	echo "ccflags-y += -DSPRINGBOARD=$target_off"
-	echo "ccflags-y += -DSTACKSIZE_SCHEDULE=$stack_size"
+	echo "ccflags-y += -DSTACKSIZE_VMLINUX=$stack_size"
 	if [ $flag_stack_protector = "Y" ]; then
 		echo "ccflags-y += -DSTACK_PROTECTOR=$stack_chk_off"
 		echo "ccflags-y += -DSTACK_PROTECTOR_LEN=$stack_chk_len"

--- a/tools/springboard_search.sh
+++ b/tools/springboard_search.sh
@@ -4,11 +4,11 @@
 
 function get_function_range()
 {
-        addrs=$(nm -n $vmlinux | grep " $1\$" -A1 | awk '{printf " 0x"$1}')
+        addrs=$(nm -n $object | grep " $1\$" -A1 | awk '{printf " 0x"$1}')
         read -r start_addr end_addr <<< "$addrs"
 
         if [ $start_addr == $end_addr ]; then
-		1>&2 echo "ERROR: __schedule function range not found in vmlinux"
+		1>&2 echo "ERROR: __schedule function range not found in target object"
                 exit 1
         fi
 
@@ -17,7 +17,11 @@ function get_function_range()
 
 function get_function_asm()
 {
-	objdump -d $vmlinux --start-address=$start_addr --stop-address=$end_addr
+	if [ "$stage" == "init" ]; then
+		objdump -d $object --start-address=$start_addr --stop-address=$end_addr
+	else
+		objdump -d $object | grep "<__schedule>:" -A30
+	fi
 }
 
 function get_stack_size_X86_64()
@@ -27,7 +31,7 @@ function get_stack_size_X86_64()
 	stack_size=${stack_size#*$}
 
 	if [ -z "${stack_size// }" ]; then
-		1>&2 echo "ERROR: stack_size of __schedule not found in vmlinux."
+		1>&2 echo "ERROR: stack_size of __schedule not found in target object."
 		exit 1
 	fi
 	echo $stack_size
@@ -40,7 +44,7 @@ function get_stack_size_AArch64()
 	stack_size=${stack_size#*-}
 
 	if [ -z "${stack_size// }" ]; then
-		1>&2 echo "ERROR: stack_size of __schedule not found in vmlinux."
+		1>&2 echo "ERROR: stack_size of __schedule not found in target object."
 		exit 1
 	fi
 	echo $stack_size
@@ -53,7 +57,7 @@ function get_springboard_target()
 	target_off=$((target_addr-start_addr))
 
 	if   [ -z "${target_off// }" ]; then
-		1>&2 echo "ERROR: springboard not found in vmlinux."
+		1>&2 echo "ERROR: springboard not found in target object."
 		exit 1
 	fi
 	echo $target_off
@@ -122,8 +126,7 @@ function read_config()
 function do_search()
 {
 	read_config
-	arch=$(readelf -h $vmlinux | awk '/Machine:/{print $NF}' | tr '-' '_')
-        eval $(get_function_range __schedule)
+	eval $(get_function_range __schedule)
 	schedule_asm="$(get_function_asm)"
 	target_off=$(get_springboard_target_$arch)
 	stack_size=$(get_stack_size_$arch)
@@ -134,10 +137,18 @@ function do_search()
 }
 
 
-vmlinux=$1
-config=$2
-if [ ! -f $vmlinux ]; then
-	1>&2 echo "Usage: springboard_search.sh <vmlinux>."
+stage=$1
+object=$2
+config=$3
+
+arch=$(readelf -h $object | awk '/Machine:/{print $NF}' | tr '-' '_')
+
+if [ "$stage" == "init" ]; then
+	do_search
+elif [ "$stage" == "build" ]; then
+	schedule_asm="$(get_function_asm)"
+	get_stack_size_$arch
+else
+	1>&2 echo "Usage: springboard_search.sh <stage> <object>."
 	exit 1
 fi
-do_search


### PR DESCRIPTION
The stack balancing relies on the frame pointer register of __schedule function now. But frame pointer register may be optimized for example in kernel 5.10. So I use another way.

The core.c will be compiled twice. The first is to get the stack size of __schedule and the value will be used for the second compilation by passing macro -DSTACKSIZE_MOD. The new way of stack balancing is following:

add sp stack_size_of_mod
sub sp stack_size_of_vmlinux