### PR TITLE
test: remove the var test of sched_rt_runtime_us

### DIFF
--- a/tests/test_var_uniformity/assert
+++ b/tests/test_var_uniformity/assert
@@ -27,7 +27,6 @@ class TestVarUniformity:
             "/proc/sys/kernel/numa_balancing_scan_size_mb",
             "/proc/sys/kernel/numa_balancing",
             "/proc/sys/kernel/sched_rt_period_us",
-            "/proc/sys/kernel/sched_rt_runtime_us",
             "/proc/sys/kernel/sched_rr_timeslice_ms",
             "/proc/sys/kernel/sched_autogroup_enabled",
             "/proc/sys/kernel/sched_cfs_bandwidth_slice_us",


### PR DESCRIPTION
In some kernel version, the sched_rt_global_constraints will restrict
the ratio rt_runtime/rt_period which leads to test failure. 

Signed-off-by: Xuchun Shang <xuchun.shang@linux.alibaba.com>