### PR TITLE
contrib: automatically tag when updating version file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+name: TagWhenVersionBump
+
+on:
+  push:
+    paths:
+      - 'module-contrib/version'
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Read version
+        run: |
+          export VERSION=$(cat ./module-contrib/version | awk '{print $NF}')
+          echo "VERSION=v$VERSION" >> $GITHUB_ENV
+      - name: Create tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: ${{ env.VERSION }}
+          message: ""


### PR DESCRIPTION
The version file was forgotten to update for quite a while, because it's
really a burden to manage both the tag and the version file at the same
time. So it's good if we only need manage one of them.

Given the fact tag comes after commit. So make a commit trigger a tag is
more practical.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>