### PR TITLE
tools: fix some compilation errors for kernel 4.19 aarch64

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -129,7 +129,7 @@ static void reset_balance_callback(void)
 }
 
 
-#if defined(CONFIG_ARM64) && defined(CONFIG_STACKPROTECTOR_PER_TASK)
+#if defined(CONFIG_ARM64) && defined(STACK_PROTECTOR)
 #define NOP 0xd503201f
 static void disable_stack_protector(void)
 {

--- a/tools/springboard_search.sh
+++ b/tools/springboard_search.sh
@@ -86,7 +86,7 @@ function get_stack_check_off_AArch64()
 		start == 1 && $3 == "ldr" {print "ldr"; next}
 		start == 1 && $3 == "ldp" {print "ldp"; next}
 		start == 1 && $3 == "ret" {print "ret"; next}
-		start == 1 && $NF== "<__schedule+'$stack_chk_fail_off'>" {print "chk"; next}
+		start == 1 && $5 == "<__schedule+'$stack_chk_fail_off'>" {print "chk"; next}
 		start == 1 {print "any"}' <<< "$schedule_asm")
 
 


### PR DESCRIPTION
There are some compilation errors when building the scheduler module
for arm64 kernel-4.19. See the first error log:

  /root/scheduler/kernel/sched/mod//main.c: In function
  'disable_stack_protector':
  /root/scheduler/kernel/sched/mod//main.c:137:35: error:
  'STACK_PROTECTOR' undeclared (first use in this function)
    137 |  void *addr = __orig___schedule + STACK_PROTECTOR;
        |                                   ^~~~~~~~~~~~~~~

  /root/scheduler/kernel/sched/mod//main.c:137:35: note: each
  undeclared identifier is reported only once for each function it
  appears in /root/scheduler/kernel/sched/mod//main.c:139:14: error:
  'STACK_PROTECTOR_LEN' undeclared (first use in this function)
    139 |  for (i=0; i<STACK_PROTECTOR_LEN; i++, addr+=4)
        |              ^~~~~~~~~~~~~~~~~~

The reason of this error is that the springboard_search.sh tool uses
the /usr/src/kernels/release-kernel/.config to determine whether the
CONFIG_STACKPROTECTOR_PER_TASK is set, but this config is added to
config file later when building the kernel in init stage, which
causes that the value of this config is "N" in the tool and "Y" in
scheduler code. So the tool should use the scheduler/.config instead
of /usr/src/kernels/release-kernel/.config.

After fix the error above, there is another error. See the second
error log:

  /root/scheduler/kernel/sched/mod//main.c:137:50: error: expected
  expression before ';' token
    137 |  void *addr = __orig___schedule + STACK_PROTECTOR;
        |                                                  ^

The reason of this error is that, the STACK_PROTECTOR and
STACK_PROTECTOR_LEN have the invalid value. See the following in
Makefile:

  ccflags-y += -DSTACK_PROTECTOR=
  ccflags-y += -DSTACK_PROTECTOR_LEN=-7

The tool wants to match the "<__schedule+0x***>" in asm of __schedule
function. But it uses the last column incorrectly, because the last
column is a comment that is invalid.

Signed-off-by: Erwei Deng <erwei@linux.alibaba.com>