### PR TITLE
border: try to remove inside callback functions out of fn_ptr set

### DIFF
--- a/boundary/analyze.py
+++ b/boundary/analyze.py
@@ -276,6 +276,9 @@ if __name__ == '__main__':
         struct_properties[struct]['public_fields'] = field_set
         struct_properties[struct]['public_users'] = user_set
 
+    assert not struct_properties['sched_class']['public_users'], \
+            'struct sched_class should be purely private'
+
     with open(tmpdir + 'header_symbol.json', 'w') as f:
         json.dump(hdr_sym, f, indent=4)
     with open(tmpdir + 'boundary_doc.yaml', 'w') as f:

--- a/boundary/collect.py
+++ b/boundary/collect.py
@@ -233,8 +233,13 @@ class Collection(object):
 
         # Find fn ptrs in variable init value
         for var in gcc.get_variables():
-            if var.decl.initial and not self.decl_in_section(var.decl, '.discard.addressable'):
-                var.decl.initial.walk_tree(mark_fn_ptr, var.decl)
+            decl = var.decl
+            type_name = '' if not decl.type.name else decl.type.name.name
+
+            # struct sched_class is purely private
+            if decl.initial and type_name != 'sched_class' and \
+                    not self.decl_in_section(decl, '.discard.addressable'):
+                decl.initial.walk_tree(mark_fn_ptr, decl)
 
     def collect_struct(self):
         public_fields = defaultdict(set)

--- a/configs/4.19/boundary.yaml
+++ b/configs/4.19/boundary.yaml
@@ -79,6 +79,8 @@ function:
         - sched_online_group
         - id_nr_invalid
         - finish_task_switch
+        - sched_exec
+        - yield
 global_var:
     extra_public:
     - cpu_idle_force_poll

--- a/configs/4.19/boundary.yaml
+++ b/configs/4.19/boundary.yaml
@@ -114,4 +114,9 @@ global_var:
     force_private:
     - sysctl_sched_features
     - sched_feat_keys
+    - stop_sched_class
+    - dl_sched_class
+    - rt_sched_class
+    - fair_sched_class
+    - idle_sched_class
 sidecar:

--- a/configs/5.10/boundary.yaml
+++ b/configs/5.10/boundary.yaml
@@ -75,6 +75,8 @@ function:
         - sched_online_group
         - id_nr_invalid
         - finish_task_switch
+        - sched_exec
+        - yield
 global_var:
     extra_public:
     - cpu_idle_force_poll

--- a/configs/5.10/boundary.yaml
+++ b/configs/5.10/boundary.yaml
@@ -113,4 +113,9 @@ global_var:
     force_private:
     - sysctl_sched_features
     - sched_feat_keys
+    - stop_sched_class
+    - dl_sched_class
+    - rt_sched_class
+    - fair_sched_class
+    - idle_sched_class
 sidecar:


### PR DESCRIPTION
W/ this patch, the number of callbacks was reduced from 163 to 73.

If one variable is marked as 'force_private', we assume it doesn't
have data dependencies with vminux.

These are the callback functions left over:
cpu_files：   6
cpu_legacy_files： 19
cpu_cgrp_subsys： 8  （ref cpu_files, cpu_legacy_files）
timer callback： 6
sysctl： 6
cpu hotplug：4
CACHE_HEADER： 4
rt/dl balance_callback：4

Signed-off-by: Shanpei Chen <shanpeic@linux.alibaba.com>