### PR TITLE
src: change the term fnptr to callback

### DIFF
--- a/boundary/extract.py
+++ b/boundary/extract.py
@@ -33,7 +33,7 @@ class Extraction(object):
         self.mod_hdrs = self.mod_files - self.mod_srcs
         self.sdcr_srcs = [f[1] for f in self.config['sidecar']]
         self.fn_list = []
-        self.fn_ptr_list = []
+        self.callback_list = []
         self.interface_list = []
         self.var_list = []
 
@@ -61,8 +61,8 @@ class Extraction(object):
             if obj in self.config['function']['sched_outsider'] or \
                obj in self.config['function']['sdcr_out']:
                 self.fn_list.append(fn),
-            elif obj in self.config['function']['fn_ptr']:
-                self.fn_ptr_list.append(fn)
+            elif obj in self.config['function']['callback']:
+                self.callback_list.append(fn)
             elif obj in self.config['function']['interface']:
                 self.interface_list.append(fn)
 
@@ -113,8 +113,8 @@ class Extraction(object):
                 for i in range(row_start+1, row_end+1):
                     lines[i] = ''
 
-        fn_ptr_export_c_fmt = "extern {ret} {fn}({params});\n"
-        for fn in self.fn_ptr_list:
+        callback_export_c_fmt = "extern {ret} {fn}({params});\n"
+        for fn in self.callback_list:
             name, decl_str = fn['name'], fn['decl_str']
             (row_start,col_start), (row_end,_) = fn['name_loc'], fn['r_brace_loc']
 
@@ -123,7 +123,7 @@ class Extraction(object):
                 lines[row_start][col_start:].replace(name, '__used ' + new_name)
             lines[row_end] = lines[row_end] + '\n' + \
                 "/* DON'T MODIFY SIGNATURE OF FUNCTION {}, IT'S CALLBACK FUNCTION */\n".format(new_name) + \
-                fn_ptr_export_c_fmt.format(**decl_str)
+                callback_export_c_fmt.format(**decl_str)
 
         for fn in self.interface_list:
             name, decl_str, (row_end,_) = fn['name'], fn['decl_str'], fn['r_brace_loc']

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,7 @@ ifneq ($(CONFIG_SCHED_OMIT_FRAME_POINTER),y)
 CFLAGS_core.o := $(PROFILING) -fno-omit-frame-pointer
 endif
 
-OBJCOPYFLAGS := --globalize-symbols $(plugsched_tmpdir)/interface_fn_ptrs
+OBJCOPYFLAGS := --globalize-symbols $(plugsched_tmpdir)/interface_callbacks
 
 objs-y += core.o
 objs-y += idle.o fair.o rt.o deadline.o

--- a/src/head_jump.h
+++ b/src/head_jump.h
@@ -10,14 +10,14 @@
 #include <linux/kallsyms.h>
 
 #define EXPORT_SIDECAR(fn, file, ...) EXPORT_PLUGSCHED(fn, __VA_ARGS__)
-#define PLUGSCHED_FN_PTR EXPORT_PLUGSCHED
+#define EXPORT_CALLBACK EXPORT_PLUGSCHED
 #define EXPORT_PLUGSCHED(fn, ...) NR_##fn,
 enum {
 	#include "export_jump.h"
 	NR_INTERFACE_FN
 } nr_inter_fn;
 #undef EXPORT_PLUGSCHED
-#undef PLUGSCHED_FN_PTR
+#undef EXPORT_CALLBACK
 
 static unsigned long vm_func_addr[NR_INTERFACE_FN];
 static unsigned long vm_func_size[NR_INTERFACE_FN];
@@ -25,21 +25,21 @@ static unsigned long mod_func_addr[NR_INTERFACE_FN];
 static unsigned long mod_func_size[NR_INTERFACE_FN];
 
 /* Used to declare the extern function set */
-#define PLUGSCHED_FN_PTR(fn, ret, ...) extern ret __mod_##fn(__VA_ARGS__);
+#define EXPORT_CALLBACK(fn, ret, ...) extern ret __mod_##fn(__VA_ARGS__);
 #define EXPORT_PLUGSCHED(fn, ret, ...) extern ret fn(__VA_ARGS__);
 #include "export_jump.h"
 #undef EXPORT_PLUGSCHED
-#undef PLUGSCHED_FN_PTR
+#undef EXPORT_CALLBACK
 
 /* Used to declare extern functions defined in vmlinux*/
-#define PLUGSCHED_FN_PTR(fn, ret, ...) extern ret __orig_##fn(__VA_ARGS__);
+#define EXPORT_CALLBACK(fn, ret, ...) extern ret __orig_##fn(__VA_ARGS__);
 #define EXPORT_PLUGSCHED(fn, ret, ...) extern ret __orig_##fn(__VA_ARGS__);
 #include "export_jump.h"
 #undef EXPORT_PLUGSCHED
-#undef PLUGSCHED_FN_PTR
+#undef EXPORT_CALLBACK
 
 /* They are completely identical unless specified */
-#define PLUGSCHED_FN_PTR EXPORT_PLUGSCHED
+#define EXPORT_CALLBACK EXPORT_PLUGSCHED
 
 /* This APIs set is used to replace the function in vmlinux with other
  * function(have the same name) in module. Usage by fallow:
@@ -143,8 +143,8 @@ static inline void jump_remove(void)
 #undef EXPORT_PLUGSCHED
 
 
-#undef PLUGSCHED_FN_PTR
-#define PLUGSCHED_FN_PTR(fn, prefix, ...) JUMP_INIT_FUNC(fn, __mod_);
+#undef EXPORT_CALLBACK
+#define EXPORT_CALLBACK(fn, prefix, ...) JUMP_INIT_FUNC(fn, __mod_);
 #define EXPORT_PLUGSCHED(fn, ...) JUMP_INIT_FUNC(fn, );
 static int __maybe_unused jump_init_all(void)
 {
@@ -152,6 +152,6 @@ static int __maybe_unused jump_init_all(void)
 	return 0;
 }
 #undef EXPORT_PLUGSCHED
-#undef PLUGSCHED_FN_PTR
+#undef EXPORT_CALLBACK
 
 #endif

--- a/src/stack_check.h
+++ b/src/stack_check.h
@@ -15,7 +15,7 @@ extern int process_id[];
 
 static void stack_check_init(void)
 {
-	#define PLUGSCHED_FN_PTR EXPORT_PLUGSCHED
+	#define EXPORT_CALLBACK EXPORT_PLUGSCHED
 	#define EXPORT_PLUGSCHED(fn, ...) 				\
 		kallsyms_lookup_size_offset((unsigned long)__orig_##fn,			 \
 				&orig_##fn##_size, NULL); 		\
@@ -23,11 +23,11 @@ static void stack_check_init(void)
 
 	#include "export_jump.h"
 	#undef EXPORT_PLUGSCHED
-	#undef PLUGSCHED_FN_PTR
+	#undef EXPORT_CALLBACK
 
 	addr_sort(vm_func_addr, vm_func_size, NR_INTERFACE_FN);
 
-	#define PLUGSCHED_FN_PTR(fn, ...) 				\
+	#define EXPORT_CALLBACK(fn, ...) 				\
 		kallsyms_lookup_size_offset((unsigned long)__mod_##fn, 	\
 				&mod_##fn##_size, NULL); 		\
 		mod_func_size[NR_##fn] = mod_##fn##_size;
@@ -39,7 +39,7 @@ static void stack_check_init(void)
 
 	#include "export_jump.h"
 	#undef EXPORT_PLUGSCHED
-	#undef PLUGSCHED_FN_PTR
+	#undef EXPORT_CALLBACK
 
 	addr_sort(mod_func_addr, mod_func_size, NR_INTERFACE_FN);
 }

--- a/tools/symbol_resolve/symbol_resolve.cpp
+++ b/tools/symbol_resolve/symbol_resolve.cpp
@@ -77,7 +77,7 @@ static void resolve_ref(const char *fname, kallsym_collection &kallsyms, sympos_
 			continue;
 		/*
 		 * Filter out the "__orig_" prefix, which represents interface
-		 * functions or function pointers defined in vmlinux.
+		 * or callback functions defined in vmlinux.
 		 */
 		if (strstr(name, "__orig_"))
 			name += sizeof("__orig_") - 1;


### PR DESCRIPTION
In most languages, `function pointer` refers to variables that stores
addresses of functions, and `callback` refers to functions that are stored
in these variables. So we misused the term `function pointer`. `callback`
should be the right and conventional term.

This patch doesn't change any funcionality.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>