### PR TITLE
border: fix "forbid redirecting mangled functions"

### DIFF
--- a/boundary/analyze.py
+++ b/boundary/analyze.py
@@ -291,7 +291,7 @@ if __name__ == '__main__':
         struct_properties[struct]['public_users'] = user_set
 
     # Sanity checks
-    assert (func_class['sidecar'] | func_class['border']) & func_class['mangled'], \
+    assert not (func_class['sidecar'] | func_class['border']) & func_class['mangled'], \
             'trying to redirect mangled functions'
     assert not struct_properties['sched_class']['public_users'], \
             'struct sched_class should be purely private'


### PR DESCRIPTION
Fix the inverted assert condition of redirecting mangled functions

Fixes: 447744cbc3a8 ("border: forbid redirecting mangled functions")
Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>