### PR TITLE
src: fix kernel panic when loading scheduler.ko

### DIFF
--- a/src/sched_rebuild.c
+++ b/src/sched_rebuild.c
@@ -16,7 +16,7 @@ extern const struct sched_class __orig_rt_sched_class;
 extern const struct sched_class __orig_fair_sched_class;
 extern const struct sched_class __orig_idle_sched_class;
 
-static struct sched_class* class[][7] = {
+static const struct sched_class* class[][8] = {
 	{
 		&fair_sched_class,
 		&rt_sched_class,


### PR DESCRIPTION
The invalid array size causes sched_class to be incorrectly initialized,
then lead to kernel panic.

Fixes: 17f974e ("src: migrate sched_class for every task during
       upgrade and rollback")

Signed-off-by: Shanpei Chen <shanpeic@linux.alibaba.com>