### PR TITLE
src: fix kernel panic during cpu hotplug test

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -60,6 +60,7 @@ ktime_t main_start, main_end, init_start, init_end;
 
 extern void clear_sched_state(bool mod);
 extern void rebuild_sched_state(bool mod);
+extern void switch_sched_class(bool mod);
 
 static int scheduler_enable = 0;
 struct kobject *plugsched_dir, *plugsched_subdir, *vmlinux_moddir;
@@ -173,6 +174,7 @@ static int __sync_sched_install(void *arg)
 		stop_time_p1 = ktime_get();
 
 	clear_sched_state(false);
+	switch_sched_class(true);
 
 	if (is_first_process()) {
 		JUMP_OPERATION(install);
@@ -215,6 +217,7 @@ static int __sync_sched_restore(void *arg)
 		stop_time_p1 = ktime_get();
 
 	clear_sched_state(true);
+	switch_sched_class(false);
 
 	if (is_first_process()) {
 		JUMP_OPERATION(remove);

--- a/src/sched_rebuild.c
+++ b/src/sched_rebuild.c
@@ -16,7 +16,9 @@ extern const struct sched_class __orig_rt_sched_class;
 extern const struct sched_class __orig_fair_sched_class;
 extern const struct sched_class __orig_idle_sched_class;
 
-static const struct sched_class* class[][8] = {
+#define SCHED_STOP 7
+
+static const struct sched_class* class[][SCHED_STOP+1] = {
 	{
 		&fair_sched_class,
 		&rt_sched_class,
@@ -39,15 +41,35 @@ static const struct sched_class* class[][8] = {
 	}
 };
 
-static void switch_sched_class(struct task_struct *p, int mod)
+void switch_sched_class(bool mod)
 {
-	int policy = p->policy;
+	struct task_struct *g, *p;
+	int task_count = 0;
+	int nr_cpus = num_online_cpus();
+	int cpu = smp_processor_id();
 	int idx = mod ? 0 : 1;
 
-	if (p == (task_rq(p)->stop))
-		policy = 7;
+	for_each_process_thread(g, p) {
+		if ((task_count % nr_cpus) == process_id[cpu]) {
+			int policy = p->policy;
 
-	p->sched_class = class[idx][policy];
+			/* kernel doesn't set policy for stopper task */
+			if (p == task_rq(p)->stop)
+				policy = SCHED_STOP;
+			p->sched_class = class[idx][policy];
+		}
+		task_count++;
+	}
+
+	if (process_id[cpu])
+		return;
+
+	for_each_possible_cpu(cpu) {
+		/* kernel doesn't set policy for idle task */
+		p = idle_task(cpu);
+		p->sched_class = class[idx][SCHED_IDLE];
+	}
+
 	return;
 }
 
@@ -98,8 +120,6 @@ void rebuild_sched_state(bool mod)
 	for_each_process_thread(g, p) {
 		if (rq != task_rq(p))
 			continue;
-
-		switch_sched_class(p, mod);
 
 		if (p == rq->stop)
 			continue;


### PR DESCRIPTION
Commit 17f974e doesn't migrate sched_class for those tasks on
offlined cpus, such as idle task, stopper, and other per-cpu
kthread. Once offline cpu come back, both old and new sched_class
exists on system, which make scheduler puzzle.

Refer to the stack check for tasks on offline cpus, using the
same way to migrate sched_class.

Fixes: 17f974e ("src: migrate sched_class for every task during
       upgrade and rollback")

Signed-off-by: Shanpei Chen <shanpeic@linux.alibaba.com>