### PR TITLE
Revert "cli: put off copying the vmlinux and Module.symver files"

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -59,12 +59,11 @@ coloredlogs.install(level='INFO')
 logging.getLogger().addHandler(ShutdownHandler())
 
 class Plugsched(object):
-    def __init__(self, work_dir, vmlinux, makefile, sym_vers):
+    def __init__(self, work_dir, vmlinux, makefile):
         self.plugsched_path = os.path.dirname(os.path.realpath(__file__))
         self.work_dir = os.path.abspath(work_dir)
         self.vmlinux = os.path.abspath(vmlinux)
         self.makefile = os.path.abspath(makefile)
-        self.sym_vers = os.path.abspath(sym_vers)
         self.mod_path = os.path.join(self.work_dir, 'kernel/sched/mod/')
         self.tmp_dir = os.path.join(self.work_dir, 'working/')
         plugsched_sh = sh(_cwd=self.plugsched_path)
@@ -150,9 +149,6 @@ class Plugsched(object):
     def extract(self):
         logging.info('Extracting scheduler module objs: %s', ' '.join(self.mod_objs))
         self.make(stage = 'collect', plugsched_tmpdir = self.tmp_dir, plugsched_modpath = self.mod_path)
-
-        self.plugsched_sh.cp(self.sym_vers, self.vmlinux, self.work_dir, force=True)
-
         self.make(stage = 'analyze', plugsched_tmpdir = self.tmp_dir, plugsched_modpath = self.mod_path)
         self.make(stage = 'extract', plugsched_tmpdir = self.tmp_dir, plugsched_modpath = self.mod_path,
                   objs = self.mod_objs)
@@ -188,10 +184,12 @@ class Plugsched(object):
                 f.truncate()
                 f.writelines(lines)
 
-    def cmd_init(self, kernel_src, kernel_config):
+    def cmd_init(self, kernel_src, sym_vers, kernel_config):
         self.create_sandbox(kernel_src)
+        self.plugsched_sh.cp(sym_vers,      self.work_dir, force=True)
         self.plugsched_sh.cp(kernel_config, self.work_dir + '/.config', force=True)
         self.plugsched_sh.cp(self.makefile, self.work_dir, force=True)
+        self.plugsched_sh.cp(self.vmlinux,  self.work_dir, force=True)
 
         logging.info('Patching kernel with pre_extract patch')
         self.apply_patch('pre_extract.patch')
@@ -292,8 +290,8 @@ if __name__ == '__main__':
         if not os.path.exists(kernel_config):
             logging.fatal("%s not found, please install kernel-devel-%s.rpm", kernel_config, release_kernel)
 
-        plugsched = Plugsched(work_dir, vmlinux, makefile, sym_vers)
-        plugsched.cmd_init(kernel_src, kernel_config)
+        plugsched = Plugsched(work_dir, vmlinux, makefile)
+        plugsched.cmd_init(kernel_src, sym_vers, kernel_config)
 
     elif arguments['dev_init']:
         kernel_src = arguments['<kernel_src>']
@@ -313,16 +311,14 @@ if __name__ == '__main__':
         if not os.path.exists(kernel_config):
             logging.fatal("kernel config %s not found", kernel_config)
 
-        plugsched = Plugsched(work_dir, vmlinux, makefile, sym_vers)
-        plugsched.cmd_init(kernel_src, kernel_config)
+        plugsched = Plugsched(work_dir, vmlinux, makefile)
+        plugsched.cmd_init(kernel_src, sym_vers, kernel_config)
 
     elif arguments['build']:
         work_dir = arguments['<work_dir>']
 
         vmlinux = os.path.join(work_dir, 'vmlinux')
         makefile = os.path.join(work_dir, 'Makefile')
-        sym_vers = os.path.join(work_dir, 'Modules.symvers')
-
-        plugsched = Plugsched(work_dir, vmlinux, makefile, sym_vers)
+        plugsched = Plugsched(work_dir, vmlinux, makefile)
         plugsched.cmd_build()
 


### PR DESCRIPTION
Commit 2ed82330(src: fix the bug kernel modules don't inflect
outsiders) aims to fix the bug that the kernel modules cannot inflect
outsiders. It uses a conservative way that is compiling the entire
kernel (includes compiling kernel modules), which will generate the
new vmlinux and modules.symver and overwrite the orignal files copied
from kernel-debuginfo and kernel-devel. It's incorrect because the
build stage must reference orignal files.

So, commit a36efadb6(cli: put off copying the vmlinux and Module.symver
files) uses a workaround to fix the problem above.

Now, plugsched does not allow exported functions to be insiders(commit
https://github.com/aliyun/plugsched/commit/f1326f6335ce035b6b0e7e5ecd976ef33a98f9e3(border: remove exported functions from internal function set)).
So it is not necessary to compile the kernel modules(commit
ba83a314(src: speed up init stage by simplifying vmlinux dependencies)).
These two commits fundamentally solve the above problem.

So the commit a36efadb is no longer needed and I revert it.