### PR TITLE
tools: fix stackprotector search for aarch64

### DIFF
--- a/tools/springboard_search.sh
+++ b/tools/springboard_search.sh
@@ -86,7 +86,7 @@ function get_stack_check_off_AArch64()
 		start == 1 && $3 == "ldr" {print "ldr"; next}
 		start == 1 && $3 == "ldp" {print "ldp"; next}
 		start == 1 && $3 == "ret" {print "ret"; next}
-		start == 1 && $5 == "<__schedule+'$stack_chk_fail_off'>" {print "chk"; next}
+		start == 1 && $6 == "<__schedule+'$stack_chk_fail_off'>" {print "chk"; next}
 		start == 1 {print "any"}' <<< "$schedule_asm")
 
 


### PR DESCRIPTION
We search stackproctors by matching "<__schedule+OFFSET>" in the assembly,
where __schedule+OFFSET points to __stack_chk_fail.

11d1a5437a2c changes stack protector matching pattern from the last column
in the assembly to the 5th column. However awk counts from 1, so it should
actually be the 6th column.

Fixes: 11d1a5437a2c ("tools: fix some compilation errors for kernel 4.19 aarch64")
Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>