### PR TITLE
tools: fix stackprotector search for aarch64

### DIFF
--- a/tools/springboard_search.sh
+++ b/tools/springboard_search.sh
@@ -117,7 +117,7 @@ function output()
 
 function read_config()
 {
-	if grep -q CONFIG_STACKPROTECTOR_PER_TASK=y $config; then
+	if grep -q CONFIG_STACKPROTECTOR=y $config; then
 		flag_stack_protector=Y
 	else
 		flag_stack_protector=N

--- a/tools/springboard_search.sh
+++ b/tools/springboard_search.sh
@@ -87,6 +87,7 @@ function get_stack_check_off_AArch64()
 		start == 1 && $3 == "ldp" {print "ldp"; next}
 		start == 1 && $3 == "ret" {print "ret"; next}
 		start == 1 && $5 == "<__schedule+'$stack_chk_fail_off'>" {print "chk"; next}
+		start == 1 && $6 == "<__schedule+'$stack_chk_fail_off'>" {print "chk"; next}
 		start == 1 {print "any"}' <<< "$schedule_asm")
 
 


### PR DESCRIPTION
We search stackproctors by matching "<__schedule+OFFSET>" in the assembly,
where __schedule+OFFSET points to __stack_chk_fail.

11d1a5437a2c changes stack protector matching pattern from the last column
in the assembly to the 5th column. Because sometimes the jump instruction
used by stack protector is "b.ne", and b.ne has only one operator. But in
other cases, the instruction might be "cbnz", which has two operators.

To take both cases into account, we should check both the 5th and the 6th
column.

Fixes: 11d1a5437a2c ("tools: fix some compilation errors for kernel 4.19 aarch64")
Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>

==========

tools: use CONFIG_STACKPROTECTOR to indicate stack_chk_fail
As long as CONFIG_STACKPROTECTOR=y is present in the config file, we can be
sure that stack_chk_fail will be generated by GCC. And we must disable it
in this case. On the other hand, CONFIG_STACKPROTECTOR_PER_TASK=y has
nothing to do we stack_chk_fail at all.

We disccussed this previously, and came the conclusion above. However the
implementation was wrong in the end, which is strange.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>
