### PR TITLE
border: fix accessing unnamed struct bug

### DIFF
--- a/boundary/collect.py
+++ b/boundary/collect.py
@@ -230,8 +230,7 @@ class Collection(object):
                     parent_component_ref[op.target] = op
 
                 context = op.field.context
-                while isinstance(op.field.type, gcc.UnionType) and op.field.name is None \
-                        and op in parent_component_ref:
+                while op.field.name is None and op in parent_component_ref:
                     op = parent_component_ref[op]
                 field = op.field
 


### PR DESCRIPTION
b9ff908f754e ("border: fix accessing union bug") fixes a bug when accessing
unnamed unions. However structs have exactly the same bug. So this patch
only checks whether,

1. Current ComponentRef's field is unnamed
2. Current ComponentRef's parent node (in the AST) is also a ComponentRef

and doesn't check whether the field is a union anymore.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>