### PR TITLE
boundary: Prevent static interface functions from being optimized

### DIFF
--- a/boundary/extract.py
+++ b/boundary/extract.py
@@ -145,12 +145,18 @@ class Extraction(object):
                                decl_fmt.format(**decl_str))
 
         for fn in self.interface_list:
-            name, (row_end, _) = fn['name'], fn['r_brace_loc']
+            name, public = fn['name'], fn['public']
+            (row_start, _), (row_end, _) = fn['name_loc'], fn['r_brace_loc']
+            used_name = '__used ' + name
 
             # everyone know that syscall ABI should be consistent
             if any(name.startswith(prefix)
                    for prefix in self.config['interface_prefix']):
                 continue
+
+            # prevent static interface functions from being optimized.
+            if not public:
+                lines[row_start] = lines[row_start].replace(name, used_name)
             lines[row_end] += if_warn.format(name)
 
     def merge_down_var(self, lines, curr):

--- a/configs/4.19/dynamic_springboard.patch
+++ b/configs/4.19/dynamic_springboard.patch
@@ -76,7 +76,7 @@ index 5ec2ca5..3b8925a 100644
   * WARNING: must be called with preemption disabled!
   */
 +__attribute__ ((optimize("no-omit-frame-pointer")))
- static void __sched notrace __schedule(bool preempt)
+ static void __sched notrace __used __schedule(bool preempt)
  {
  	struct task_struct *prev, *next;
 2.20.1.2432.ga663e714


### PR DESCRIPTION
If we want to replace static functions, these functions in module must
not be optimized, or we will replace the entry with wrong jmp and cause
softlockup due to endless loop.

Add "__used" for static interface functions to prevent this.