### PR TITLE
tools: stop supporting builtin springboard

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -197,13 +197,8 @@ class Plugsched(object):
         self.extract()
         logging.info('Patching extracted scheduler module with post_extractd patch')
         self.apply_patch('post_extract.patch')
-
-        # special handle for builtin springboard kernel version
-        try:
-            sh.grep('label_recover', os.path.join(self.work_dir, 'kernel/sched/core.c'))
-        except:
-            logging.info('Patching dynamic springboard')
-            self.apply_patch('dynamic_springboard.patch')
+        logging.info('Patching dynamic springboard')
+        self.apply_patch('dynamic_springboard.patch')
 
         with open(os.path.join(self.mod_path, 'Makefile'), 'a') as f:
             self.search_springboard('init', self.vmlinux, kernel_config, _out=f)

--- a/configs/4.19/dynamic_springboard.patch
+++ b/configs/4.19/dynamic_springboard.patch
@@ -26,8 +26,7 @@ index 5ec2ca5..3b8925a 100644
  static __always_inline struct rq *
  context_switch(struct rq *rq, struct task_struct *prev,
  	       struct task_struct *next, struct rq_flags *rf)
-@@ -2634,7 +2636,43 @@ context_switch(struct rq *rq, struct task_struct *prev,
- 	prepare_lock_switch(rq, next, rf);
+@@ -2634,3 +2636,39 @@ context_switch(struct rq *rq, struct task_struct *prev,
  
  	/* Here we just switch the register state and the stack. */
 -	switch_to(prev, next, prev);
@@ -68,9 +67,6 @@ index 5ec2ca5..3b8925a 100644
 +#endif
 +
 +	/* Below will not be executed, we'll return to vmlinux here */
- 	barrier();
- 
- 	return finish_task_switch(prev);
 @@ -3178,6 +3190,7 @@ again:
   *
   * WARNING: must be called with preemption disabled!

--- a/tools/springboard_search.sh
+++ b/tools/springboard_search.sh
@@ -4,21 +4,22 @@
 
 function get_function_range()
 {
-        addrs=$(nm -n $object | grep " $1\$" -A1 | awk '{printf " 0x"$1}')
-        read -r start_addr end_addr <<< "$addrs"
+        addr_size=$(nm -S $object | grep " $1\$" | awk '{print "0x"$1,"0x"$2}')
+        read -r start_addr size <<< "$addr_size"
 
-        if [ $start_addr == $end_addr ]; then
+        if [ "$start_addr" == "" ]; then
 		1>&2 echo "ERROR: __schedule function range not found in target object"
                 exit 1
         fi
 
+        end_addr=$(python3 -c "print(hex($start_addr + $size))")
         echo "start_addr=$start_addr; end_addr=$end_addr"
 }
 
 function get_function_asm()
 {
 	if [ "$stage" == "init" ]; then
-		objdump -d $object --start-address=$start_addr --stop-address=$end_addr
+		objdump -d $object --start-address=$start_addr --stop-address=$end_addr | sed '/^$/d'
 	else
 		objdump -d $object | grep "<__schedule>:" -A30
 	fi


### PR DESCRIPTION
Once we have some kernels customized for plugsched. And we patched these
kernels with builtin springboards. Now that dynamic springboard is mature
enough, and doesn't require any customizing to the kernel, we can delete
the support for builtin springboard.

Also, this patch fixes the bug, that plugsched fails to work on some of
these kernels. Because currently, dynamic_springboard.patch is composed
of stack-pivot and springboard. And for these kernels, stack-pivot is
not applied as well. Without stack-pivot, the scheduler is easily broken.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>