### PR TITLE
border: introduce PEP8 code style for collect.py

### DIFF
--- a/src/Makefile.plugsched
+++ b/src/Makefile.plugsched
@@ -5,8 +5,7 @@ include Makefile
 
 GCC_PLUGIN_FLAGS := -fplugin=/usr/lib64/gcc-python-plugin/python.so \
 		    -fplugin-arg-python-script=$(plugsched_tmpdir)/collect.py \
-		    -fplugin-arg-python-tmpdir=$(plugsched_tmpdir) \
-		    -fplugin-arg-python-modpath=$(plugsched_modpath)
+		    -fplugin-arg-python-tmpdir=$(plugsched_tmpdir)
 
 PHONY += plugsched collect extract
 


### PR DESCRIPTION
Here are some major code style changes:

1. yapf -i border/analyze.py
2. write short comments for functions and classes;
3. limit all lines to a maximum of 79 characters;
4. delete unused import;
5. change names for some variable and function;
6. use single quotes when accessing dictionary keys;

Signed-off-by: Shanpei Chen <shanpeic@linux.alibaba.com>