### PR TITLE
tools: fix stack protector search

### DIFF
--- a/tools/springboard_search.sh
+++ b/tools/springboard_search.sh
@@ -83,7 +83,7 @@ function get_stack_check_off_AArch64()
 	stack_chk_fail_off=$(printf "0x%x" $((stack_chk_fail-start_addr)))
 
 	asm_sequence=$(awk '
-		$NF == "<__schedule>:" {start = 1; next}
+		/Disassembly of section/ {start = 1; next}
 		start == 1 && $3 == "ldr" {print "ldr"; next}
 		start == 1 && $3 == "ldp" {print "ldp"; next}
 		start == 1 && $3 == "ret" {print "ret"; next}


### PR DESCRIPTION
00a24b77eed7 ("tools: stop supporting builtin springboard") removes
<__schedule:> from asm_sequence, but still matches it when searching
stackprotector. Since the asm_sequence is disassembly of __schedule
function now, "start" variable can be safely deleted now. And after
deleting it, stackprotector searching works now.

Fixes: 00a24b77eed7 ("tools: stop supporting builtin springboard")
Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>