### PR TITLE
border: fix GCC optimization of fields accessing grouping

### DIFF
--- a/boundary/collect.py
+++ b/boundary/collect.py
@@ -230,10 +230,12 @@ class Collection(object):
                 context = op.field.context
                 while op.field.name is None and op in parent_component_ref:
                     op = parent_component_ref[op]
-                field = op.field
 
                 loc_file = os.path.relpath(context.stub.location.file)
                 if loc_file in self.mod_hdrs and context.name is not None:
+                    # When acecssing 2 32bit fields at one time, the AST
+                    # ancestor is BitFieldRef. And op.field.name is None
+                    field = op.field.name or '<unknown>'
                     public_fields[context].add((node.decl, field))
 
         for node in gcc.get_callgraph_nodes():
@@ -251,7 +253,7 @@ class Collection(object):
             self.struct_properties[struct.name.name] = {
                 "all_fields": [f.name for f in struct.fields if f.name],
                 "public_fields": groupby(user_fields,
-                    grouper=lambda user_and_field: user_and_field[1].name,
+                    grouper=lambda user_and_field: user_and_field[1],
                     selector=lambda user_and_field: (user_and_field[0].name, os.path.relpath(user_and_field[0].location.file)))
             }
 


### PR DESCRIPTION
For `union bpf_attr`, when visiting attr->bpf_fd and attr->file_flags,
GCC optimizes these two u32 to one u64. i.e.

    attr->bpf_fd & 0xBEEF || attr->file_flags & 0xDEAD

becomes,

    tmp = *(struct unnamed_struct*)((unsigned long)attr+8)
    tmp | 0xdead0000beef

The current algorithm failed to handle this, because GCC thinks there are
only one ComponentRef, but it sees `bpf_fd` and `file_flags` as a whole
field, which is anonymous too. This leads to crash when sorting of fields
by their name.

This can be fixed by ignoring the field's name, and using a fixed fake
name `<unknown>` instead. In this case, the most important information is
union name bpf_attr, other names, such as bpf_fd and file_flags, can be
ignored if them are hard to get.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>