### PR TITLE
src: ensure redirect after clear_sched_state is done

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -168,6 +168,8 @@ static int __sync_sched_install(void *arg)
 
 	if ((error = atomic_read(&global_error))) {
 		print_error(error);
+		atomic_dec(&clear_finished);
+		atomic_dec(&redirect_finished);
 		return error;
 	}
 
@@ -214,6 +216,8 @@ static int __sync_sched_restore(void *arg)
 
 	if ((error = atomic_read(&global_error))) {
 		print_error(error);
+		atomic_dec(&clear_finished);
+		atomic_dec(&redirect_finished);
 		return error;
 	}
 


### PR DESCRIPTION
clear_sched_state should use the currently running scheduler's functions to
perform clearing, instead of using the to-be-loaded scheduler's functions.
On the contrary, rebuild_sched_state should use the to-be-loaded scheduler.

The first CPU may run very slow, and after some other CPUs finish
redirecting scheduler functions. Then the first CPU violates the rule above.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>