### PR TITLE
src: Check header modified by ftrace or sth before install

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -582,7 +582,8 @@ static int __init sched_mod_init(void)
 
 	sched_springboard = (unsigned long)__orig___schedule + SPRINGBOARD;
 
-	jump_init_all();
+	if (jump_init_all())
+		return -EBUSY;
 
 	/* This must after jump_init_all function !!! */
 	stack_check_init();

--- a/tests/run_test
+++ b/tests/run_test
@@ -16,6 +16,7 @@ for T in ${tests}; do
 	if test_$T/assert; then
 		echo -e "$T test ${GREEN}PASS${RESET}"
 	else
+		dmesg -c
 		echo -e "$T test ${RED}FAILED${RESET}"
 	fi
 done

--- a/tests/test_mem_pressure/assert
+++ b/tests/test_mem_pressure/assert
@@ -61,6 +61,7 @@ class TestMemPressure:
             rpm('-e', 'scheduler-xxx')
         except Exception:
             self.check_oom(target)
+            raise
 
     def test_all(self):
         for level in range(1, self.iterations + 4):


### PR DESCRIPTION
Backoff when there's already ftrace on a function. Because if we insist on
overwritting function header, ftrace gets confused about its meta data and
may panic the kernel.

Ftrace and other similar infrastructures use call and jmp to do dynamic
patching. So we compare the first byte against 0xe8/0xe9 to see if we
should back off. For now, only x86-64 arch is supported.

