### PR TITLE
src: exploit vmlinux's call to avoid ROP

### DIFF
--- a/configs/4.19/dynamic_springboard.patch
+++ b/configs/4.19/dynamic_springboard.patch
@@ -26,15 +26,14 @@ index 5ec2ca5..3b8925a 100644
  static __always_inline struct rq *
  context_switch(struct rq *rq, struct task_struct *prev,
  	       struct task_struct *next, struct rq_flags *rf)
-@@ -2634,3 +2636,39 @@ context_switch(struct rq *rq, struct task_struct *prev,
+@@ -2634,3 +2636,37 @@ context_switch(struct rq *rq, struct task_struct *prev,
  
  	/* Here we just switch the register state and the stack. */
 -	switch_to(prev, next, prev);
 +#ifdef CONFIG_X86_64
 +	prepare_switch_to(next);
 +	__asm__("add %0,%%rsp\n\t"
-+		"pushq %1\n\t"
-+		"jmp __switch_to_asm"
++		"jmp *%1\n\t"
 +		:
 +		:"i"(STACKSIZE_MOD - STACKSIZE_VMLINUX), "r"(sched_springboard), "D"(prev), "S"(next)
 +		:"rbx","r12","r13","r14","r15"
@@ -57,10 +56,9 @@ index 5ec2ca5..3b8925a 100644
 +		"stp x27,x28,[sp, #80]\n\t"
 +		"mov x0,%2\n\t"
 +		"mov x1,%3\n\t"
-+		"ldr x30,%1\n\t"
-+		"b __switch_to"
++		"br %1"
 +		:
-+		:"i"(STACKSIZE_VMLINUX), "m"(sched_springboard),"r"(prev),"r"(next)
++		:"i"(STACKSIZE_VMLINUX), "r"(sched_springboard),"r"(prev),"r"(next)
 +		:"x19","x20","x21","x22","x23","x24","x25",
 +		 "x26","x27","x28","x30","x0","x1"
 +	);

--- a/tools/springboard_search.sh
+++ b/tools/springboard_search.sh
@@ -53,7 +53,7 @@ function get_stack_size_AArch64()
 
 function get_springboard_target()
 {
-	target_addr=$(awk '$NF == "<'$1'>"{getline; print $1; exit}' <<< "$schedule_asm")
+	target_addr=$(awk '$NF == "<'$1'>"{print $1; exit}' <<< "$schedule_asm")
 	target_addr=0x${target_addr%:*}
 	target_off=$((target_addr-start_addr))
 


### PR DESCRIPTION
ROP is a hacker technique, which manipulates data on the stack directly. And this new method expolits vmlinux's call instruction like,

__schedule(scheduler)     __schedule(vmlinux)       __switch_to(vmlinux)
   mov prev, rdi                mov prev, rdi
   mov next, rsi                mov next, rsi
   add diff-stack-size, rsp
   jmp                   --->   call __switch_to  ---> push rbp
                                mov rax,*  <--.        ...
                                               \       pop rbp
                                                .---   ret

This solution is simpler than the previous one based on ROP.

Suggested-by: Erwei Deng <erwei@linux.alibaba.com>
Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>