### PR TITLE
border: forbid getting non-exist attr in dotdicts

### DIFF
--- a/boundary/analyze.py
+++ b/boundary/analyze.py
@@ -294,7 +294,7 @@ def get_func_decl_strs(signatures, fmt):
 
 class dotdict(dict):
     """dot.notation access to dictionary attributes"""
-    __getattr__ = dict.get
+    __getattr__ = dict.__getitem__
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
 
@@ -352,7 +352,7 @@ if __name__ == '__main__':
                 hdr_sym['fn'].append(fn)
             if fn.init:
                 func_class.init.add(fn.signature)
-            if fn.publ:
+            if fn.public:
                 global_fn_dict[fn.name] = fn.file
 
         for fn in meta['interface']:


### PR DESCRIPTION
Before this patch, dotdict.attr returns None when attr doesn't exist in dotdict, because "." operator is overwritten by "get" method. This behaviour hides bugs, and we don't benefit from this behavior at all. So this patch makes dotdict raising exceptions when attr doesn't exist, just likey "__getitem__" does.

By the way, fix a bug in "fn.publ", where "publ" should actually be "public". This bug is just hidden by this behaviour.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>