### PR TITLE
src: fix race condition of global_error

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -159,9 +159,9 @@ static int __sync_sched_install(void *arg)
 	}
 
 	error = stack_check(true);
-	atomic_dec(&cpu_finished);
 	if (error)
 		atomic_cmpxchg(&global_error, 0, error);
+	atomic_dec(&cpu_finished);
 
 	/* wait for all cpu to finish stack check */
 	atomic_cond_read_relaxed(&cpu_finished, !VAL);
@@ -207,9 +207,9 @@ static int __sync_sched_restore(void *arg)
 		stop_time_p0 = ktime_get();
 
 	error = stack_check(false);
-	atomic_dec(&cpu_finished);
 	if (error)
 		atomic_cmpxchg(&global_error, 0, error);
+	atomic_dec(&cpu_finished);
 
 	/* wait for all cpu to finish stack check */
 	atomic_cond_read_relaxed(&cpu_finished, !VAL);


### PR DESCRIPTION
Here's a race condition of global_error. As we decrese cpu_finished before we assign error to global_error, the CPUs without error may not notice that error has occurred on other CPUs, which will cause panic. Here follows the timing diagram of this race condition.

     CPU x			              CPU y
stack_check pass
cpu_finished dec	        stack_check fail
wait cpu_finished == 0	cpu_finished dec to 0
read global_error	         check cpu_finished ==0
normal path		         global_error = error
			                  error handling

To fix this problem, we assign error to global_error before we decrese cpu_finished, so that we can guarantee that every CPU can get the correct global_error.

Signed-off-by: Cruz Zhao <CruzZhao@linux.alibaba.com>