### PR TITLE
border: fix "keep only one if both strong and weak symbol exist"

### DIFF
--- a/boundary/analyze.py
+++ b/boundary/analyze.py
@@ -261,6 +261,7 @@ def func_class_arithmetics(fns):
     fns.inflect_cut = fns.border | fns.init | fns.sidecar
     fns.insider = inflect(fns.initial_insider, edges) - fns.init
     fns.sched_outsider = (fns.mod_fns - fns.insider - fns.border) | fns.cb_opt
+    fns.sched_outsider |= fns.fake_global & fns.mod_fns
     fns.outsider_opt = fns.sched_outsider - fns.in_vmlinux - fns.init
     fns.public_user = fns.fn - fns.insider - fns.border
     fns.tainted = (fns.border | fns.insider | fns.sidecar) & fns.in_vmlinux
@@ -329,6 +330,7 @@ if __name__ == '__main__':
         'sdcr_fns': set(),
         'interface': set(),
         'weak': set(),
+        'fake_global': set(),
     })
 
     edges = []
@@ -375,6 +377,9 @@ if __name__ == '__main__':
         if name != 'main' and len(fn_list) != 1 and fn_list[0][0] == fn_list[1][0]:
             print('warning: Can\'t tell which %s is linked in vmlinux!' % name)
         global_fn_dict[name] = fn_list[0][1]
+        for prio, file in fn_list[1:]:
+            if prio in (WEAK_ARCH, WEAK_NORM):
+                func_class.fake_global.add((name, file))
 
     # second pass: fix vague filename, calc callback and edge set
     for meta in metas:

--- a/boundary/analyze.py
+++ b/boundary/analyze.py
@@ -276,17 +276,10 @@ def get_func_decl_strs(signatures, fmt):
     for fn in signatures:
         (name, file) = fn
         s = fmt.format(**decls[fn])
-
         if file != global_fn_dict.get(name):
-            local_syms.add(name)
-
-        """If there are two global symbols, then one must be weak and
-        the other strong. Otherwise, original kernel fails to compile.
-        """
-        if s in decl_strs:
             assert name not in local_syms, \
                 'Attempt to redirect a repeating local symbol %s' % str(fn)
-            continue
+            local_syms.add(name)
         decl_strs.add(s)
 
     return decl_strs
@@ -298,6 +291,13 @@ class dotdict(dict):
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
 
+"""Strong symbols override weak symbols. Because arch/built-in.a comes
+before kernel/built-in.a when creating built-in.a, architecture-specific
+weak symbols override general weak symbols.
+"""
+WEAK_NORM = 3
+WEAK_ARCH = 2
+STRONG    = 1
 
 if __name__ == '__main__':
     vmlinux = sys.argv[1]
@@ -328,6 +328,7 @@ if __name__ == '__main__':
         'callback': set(),
         'sdcr_fns': set(),
         'interface': set(),
+        'weak': set(),
     })
 
     edges = []
@@ -353,10 +354,27 @@ if __name__ == '__main__':
             if fn.init:
                 func_class.init.add(fn.signature)
             if fn.public:
-                global_fn_dict[fn.name] = fn.file
+                if fn.weak or fn.file.endswith('.c'):
+                    global_fn_dict.setdefault(fn.name, set())
+
+                if fn.weak and fn.file.startswith('arch/'):
+                    global_fn_dict[fn.name].add((WEAK_ARCH, fn.file))
+                elif fn.weak:
+                    global_fn_dict[fn.name].add((WEAK_NORM, fn.file))
+                elif fn.file.endswith('.c'):
+                    global_fn_dict[fn.name].add((STRONG, fn.file))
+
+            if fn.weak:
+                func_class.weak.add(fn.signature)
 
         for fn in meta['interface']:
             func_class.interface.add(tuple(fn))
+
+    for name, fn_list in global_fn_dict.items():
+        fn_list = sorted(fn_list)
+        if name != 'main' and len(fn_list) != 1 and fn_list[0][0] == fn_list[1][0]:
+            print('warning: Can\'t tell which %s is linked in vmlinux!' % name)
+        global_fn_dict[name] = fn_list[0][1]
 
     # second pass: fix vague filename, calc callback and edge set
     for meta in metas:

--- a/boundary/collect.py
+++ b/boundary/collect.py
@@ -128,6 +128,10 @@ class Collection(object):
                 return val[0].constant == section
         return False
 
+    def decl_is_weak(self, decl):
+        """Whether declaration is weak"""
+        return '__weak__' in decl.attributes or 'weak' in decl.attributes
+
     def collect_fn(self):
         """Collect all funtion properties, including interface functions"""
         src_f = gcc.get_main_input_filename()
@@ -155,6 +159,7 @@ class Collection(object):
                 'public': decl.public,
                 'static': decl.static,
                 'inline': decl.inline or 'always_inline' in decl.attributes,
+                'weak': self.decl_is_weak(decl),
                 'signature': self.decl_sig(decl),
                 'decl_str': None,
             }

--- a/src/Makefile.plugsched
+++ b/src/Makefile.plugsched
@@ -16,6 +16,8 @@ collect: modules_prepare
 	$(MAKE) CFLAGS_KERNEL="$(GCC_PLUGIN_FLAGS)" \
 		CFLAGS_MODULE="$(GCC_PLUGIN_FLAGS)" $(vmlinux-dirs)
 analyze:
+	find $(srctree)/arch -name "compressed" -type d | xargs -I% find % -name "*.c.boundary" -exec rm -f {} \;
+	rm -f $(srctree)/drivers/firmware/efi/libstub/*.c.boundary
 	python3 $(plugsched_tmpdir)/analyze.py ./vmlinux $(plugsched_tmpdir) $(plugsched_modpath)
 
 extract: $(objs)


### PR DESCRIPTION
If there are a strong and a weak one, global_fn_dict will be overwritten because they're both public. Then get_func_decl_strs mistooks one of them as local symbol and fail to assert.

This bugfix takes the advantage of the fact: strong symbols are unique. (Although we hope weak symbols are unique too, but GCC seems to allow that)

So now "global_fn_dict" is actually "global_strong_fn_dict". And now we can divided all functions into 1) strong global 2) weak global 3) local. We use func_class to store all weak symbols. Then if a symbol is neither 1) nor 2), we know it's a local symbol.

Fixes: 89e09ed133e7 ("border: keep only one if both strong and weak symbol exist")
Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>