### PR TITLE
Fix sched class

### DIFF
--- a/boundary/extract.py
+++ b/boundary/extract.py
@@ -252,7 +252,11 @@ class Extraction(object):
     def fix_up(self, lines):
         """Post fix trival code adaption"""
         delete = re.compile('initcall|early_param|__init |__initdata |__setup')
-        replace_list = [('struct atomic_t', 'atomic_t')]
+        replace_list = [
+            (re.compile(r'struct atomic_t'), r'atomic_t'),
+            (re.compile(r'(^const .*) ((stop|dl|rt|fair|idle)_sched_class)'),
+             r'\1 shadow_\2'),
+        ]
 
         for (i, line) in enumerate(lines):
             if '#include "' in line:
@@ -267,8 +271,8 @@ class Extraction(object):
                 continue
 
             for (p, repl) in replace_list:
-                if p in line:
-                    lines[i] = line.replace(p, repl)
+                if p.search(line):
+                    lines[i] = p.sub(repl, line)
                     break
 
     def extract_file(self):

--- a/src/main.c
+++ b/src/main.c
@@ -181,8 +181,8 @@ static int __sync_sched_install(void *arg)
 	/* wait for all cpu to finish state rebuild */
 	atomic_cond_read_relaxed(&clear_finished, !VAL);
 
-	switch_sched_class(true);
 	if (is_first_process()) {
+		switch_sched_class(true);
 		JUMP_OPERATION(install);
 		disable_stack_protector();
 		sched_alloc_extrapad();
@@ -229,8 +229,8 @@ static int __sync_sched_restore(void *arg)
 	/* wait for all cpu to finish state rebuild */
 	atomic_cond_read_relaxed(&clear_finished, !VAL);
 
-	switch_sched_class(false);
 	if (is_first_process()) {
+		switch_sched_class(false);
 		JUMP_OPERATION(remove);
 		reset_balance_callback();
 		sched_free_extrapad();


### PR DESCRIPTION
    src: sync the state of sched_class variables in place

    To mark struct sched_class as private, commit 17f974e migrates
    sched_class for every task. However, there are race windows during
    task fork and task exit. In both cases, sched_class are inconsistent,
    will lead to kernel panic. E.G:

    copy_process():
      ->sched_fork()-> init to old sched_class
      ... (might sleep)

      ... plugsched fail to switch sched_class, for the new task is
          still not attacted to task_list.

      ->list_add_tail_rcu(&p->tasks, &init_task.tasks)
      ... using old sched_class!!!

    do_exit():
      ->exit_notify()->release_task()->__exit_signal()->__unhash_process()
          ->list_del_rcu(&p->tasks)
      ... (maight sleep)

      ... plugsched fail to switch sched_class, for the dead task is
          detached from task_list now.

      ->do_task_dead()->__schedule()->dequeue_task()
      ... using new sched_class!!!

    This patch fix it by sharing sched_class variables between vmlinux and
    scheduler module, but re-init their state during scheduler upgrade and
    rollback.
