### PR TITLE
src: fix compile error on aarch64 platform

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -182,8 +182,10 @@ static int __sync_sched_install(void *arg)
 	atomic_cond_read_relaxed(&clear_finished, !VAL);
 
 	if (is_first_process()) {
+		disable_write_protect();
 		switch_sched_class(true);
-		JUMP_OPERATION(install);
+		jump_install();
+		enable_write_protect();
 		disable_stack_protector();
 		sched_alloc_extrapad();
 		reset_balance_callback();
@@ -230,8 +232,10 @@ static int __sync_sched_restore(void *arg)
 	atomic_cond_read_relaxed(&clear_finished, !VAL);
 
 	if (is_first_process()) {
+		disable_write_protect();
 		switch_sched_class(false);
-		JUMP_OPERATION(remove);
+		jump_remove();
+		enable_write_protect();
 		reset_balance_callback();
 		sched_free_extrapad();
 	}

--- a/src/sched_rebuild.c
+++ b/src/sched_rebuild.c
@@ -41,18 +41,10 @@ struct sched_class *mod_class[] = {
 struct sched_class bak_class[NR_SCHED_CLASS];
 
 
-static inline void do_write_cr0(unsigned long val)
-{
-        asm volatile("mov %0,%%cr0": "+r" (val) : : "memory");
-}
-
 void switch_sched_class(bool mod)
 {
 	int i;
 	int size = sizeof(struct sched_class);
-	unsigned long cr0 = read_cr0();
-
-	do_write_cr0(cr0 & 0xfffeffff);
 
 	for (i = 0; i < NR_SCHED_CLASS; i++) {
 		if (mod) {
@@ -62,8 +54,6 @@ void switch_sched_class(bool mod)
 			memcpy(orig_class[i], &bak_class[i], size);
 		}
 	}
-
-	do_write_cr0(cr0);
 }
 
 void clear_sched_state(bool mod)


### PR DESCRIPTION
CR0 is specific to x86, can't work on aarch64. Using helper functions to fix it.

Fixes: c4b4734 (src: sync the state of sched_class variables
       in place)

Signed-off-by: Shanpei Chen <shanpeic@linux.alibaba.com>