### PR TITLE
Fix the compiling error of modification of sched_class on arm64

### DIFF
--- a/src/head_jump.h
+++ b/src/head_jump.h
@@ -93,19 +93,12 @@ extern void __orig___fentry__(void);
 #define JUMP_REMOVE_FUNC(func) 	\
 	memcpy((unsigned char *)__orig_##func, store_orig_##func, HEAD_LEN)
 
-static inline void do_write_cr0(unsigned long val)
-{
-	asm volatile("mov %0,%%cr0": "+r" (val) : : "memory");
-}
 
 /* Must be used in stop machine context */
 #define JUMP_OPERATION(ops) do { 	\
-		unsigned long cr0;      \
-					\
-		cr0 = read_cr0();       \
-		do_write_cr0(cr0 & 0xfffeffff);    \
-		jump_##ops();		\
-		do_write_cr0(cr0);         \
+		void *unused = disable_write_protect(NULL); \
+		jump_##ops();	\
+		enable_write_protect(); \
 	} while(0)
 
 #else /* For ARM64 */

--- a/src/helper.h
+++ b/src/helper.h
@@ -6,6 +6,55 @@
  * helper function to communicate with vmlinux
  */
 
+#ifdef CONFIG_X86_64
+static unsigned long orig_cr0;
+
+static inline void do_write_cr0(unsigned long val)
+{
+	asm volatile("mov %0,%%cr0": "+r" (val) : : "memory");
+}
+
+static inline void *disable_write_protect(void *addr)
+{
+	BUG_ON(orig_cr0);
+
+	orig_cr0 = read_cr0();
+	do_write_cr0(orig_cr0 & 0xfffeffff);
+
+	return (void *)addr;
+}
+
+static inline void enable_write_protect(void)
+{
+	do_write_cr0(orig_cr0);
+	orig_cr0 = 0;
+}
+
+#else /* ARM64 */
+
+#include <asm/insn.h>
+#include <asm/fixmap.h>
+#include <asm/memory.h>
+#include <asm/cacheflush.h>
+
+static void *disable_write_protect(void *addr)
+{
+	unsigned long uintaddr = (uintptr_t) addr;
+	struct page *page;
+
+	page = phys_to_page(__pa_symbol(addr));
+
+	return (void *)set_fixmap_offset(FIX_TEXT_POKE0, page_to_phys(page) +
+			(uintaddr & ~PAGE_MASK));
+}
+
+static inline void enable_write_protect(void)
+{
+	clear_fixmap(FIX_TEXT_POKE0);
+}
+#endif
+
+
 static inline unsigned long get_ptr_value(unsigned long ptr_addr)
 {
 	unsigned long mid_addr = *((unsigned long *)ptr_addr);

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include <linux/sysfs.h>
 #include <linux/version.h>
 #include "sched.h"
+#include "helper.h"
 #include "mempool.h"
 #include "head_jump.h"
 #include "stack_check.h"

--- a/src/stack_check.h
+++ b/src/stack_check.h
@@ -4,7 +4,6 @@
 #include <linux/list.h>
 #include <trace/events/sched.h>
 #include <linux/stacktrace.h>
-#include "helper.h"
 
 #define MAX_STACK_ENTRIES	100
 


### PR DESCRIPTION
I don't find a way to disable global write protect on arm64, so I use the fixmap again to fix this bug.