### PR TITLE
Adjust the boundary of 5.10.

### DIFF
--- a/configs/5.10/boundary.yaml
+++ b/configs/5.10/boundary.yaml
@@ -34,12 +34,13 @@ function:
         - send_call_function_single_ipi
         - do_set_cpus_allowed
         - set_user_nice
-        - sched_setscheduler
+        - __sched_setscheduler
         - sched_setscheduler_nocheck
         - __set_cpus_allowed_ptr
         - schedule_tail
         - scheduler_tick
         - sched_fork
+        - sched_post_fork
         - __schedule
         - resched_cpu
         - task_rq_lock
@@ -52,7 +53,7 @@ function:
         - wake_up_nohz_cpu
         - rt_mutex_setprio
         - idle_cpu
-        - partition_sched_domains
+        - partition_sched_domains_locked
         - sched_set_stop_task
         - task_numa_group_id
         - should_numa_migrate_memory


### PR DESCRIPTION
Some members of sched_class are used by outsider functions which means that the boundary of kernel 5.10 is not complete. See the boundary_doc.yaml:

  public_fields:
  - dequeue_task
  - enqueue_task
  - set_next_task
  - rq_online
  - task_fork
  - put_prev_task
  - switched_from
  - switched_to
  - prio_changed
  - rq_offline

So I make some adjustion of this boundary.