### PR TITLE
Update the dynamic_springboard.patch of 5.10.

### DIFF
--- a/configs/5.10/dynamic_springboard.patch
+++ b/configs/5.10/dynamic_springboard.patch
@@ -8,32 +8,16 @@ Subject: [PATCH] Dynamic __schedule springboard
 
 With this springboard, we don't have to customize the kernel's __schedule.
 
-In order to match the layout of stack of __schedule in vmlinux, I change
-the attribute of prepare_task_switch to noinline which is because that,
-the frame pointer in vmlinux is optimized but not in scheduler. Whether
-the prepare_task_switch is inlined can infect whether the frame pointer
-of __schedule in module is optimized.
-
 Co-developed-by: Yihao Wu <wuyihao@linux.alibaba.com>
 Signed-off-by: Erwei Deng <erwei@linux.alibaba.com>
-
 ---
- kernel/sched/mod/core.c | 39 +++++++++++++++++++++++++++++++++++++--
- 1 file changed, 37 insertions(+), 2 deletions(-)
+ kernel/sched/mod/core.c | 38 +++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 37 insertions(+), 1 deletion(-)
 
 diff --git a/kernel/sched/mod/core.c b/kernel/sched/mod/core.c
-index eee32739c..49bf0d72d 100644
+index eee32739c..26ccde413 100644
 --- a/kernel/sched/mod/core.c
 +++ b/kernel/sched/mod/core.c
-@@ -3249,7 +3249,7 @@ static inline void finish_lock_switch(struct rq *rq)
-  * prepare_task_switch sets up locking and calls architecture specific
-  * hooks.
-  */
--static inline void
-+static noinline void
- prepare_task_switch(struct rq *rq, struct task_struct *prev,
- 		    struct task_struct *next)
- {
 @@ -3417,6 +3417,8 @@ asmlinkage __visible void schedule_tail(struct task_struct *prev)
  /*
   * context_switch - switch to the new MM and the new thread's register state.
@@ -85,6 +69,14 @@ index eee32739c..49bf0d72d 100644
  	barrier();
  
  	return finish_task_switch(prev);
+@@ -4066,6 +4101,7 @@ pick_next_task(struct rq *rq, struct task_struct *prev, struct rq_flags *rf)
+  *
+  * WARNING: must be called with preemption disabled!
+  */
++__attribute__ ((optimize("no-omit-frame-pointer")))
+ static void __sched notrace __used __schedule(bool preempt)
+ {
+ 	struct task_struct *prev, *next;
 -- 
 2.27.0
 

--- a/configs/5.10/dynamic_springboard.patch
+++ b/configs/5.10/dynamic_springboard.patch
@@ -18,14 +18,14 @@ Co-developed-by: Yihao Wu <wuyihao@linux.alibaba.com>
 Signed-off-by: Erwei Deng <erwei@linux.alibaba.com>
 
 ---
- kernel/sched/mod/core.c | 41 +++++++++++++++++++++++++++++++++++++++--
- 1 file changed, 39 insertions(+), 2 deletions(-)
+ kernel/sched/mod/core.c | 39 +++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 37 insertions(+), 2 deletions(-)
 
 diff --git a/kernel/sched/mod/core.c b/kernel/sched/mod/core.c
-index d665eac45..f5038f4f0 100644
+index eee32739c..49bf0d72d 100644
 --- a/kernel/sched/mod/core.c
 +++ b/kernel/sched/mod/core.c
-@@ -3228,7 +3228,7 @@ static inline void finish_lock_switch(struct rq *rq)
+@@ -3249,7 +3249,7 @@ static inline void finish_lock_switch(struct rq *rq)
   * prepare_task_switch sets up locking and calls architecture specific
   * hooks.
   */
@@ -34,7 +34,7 @@ index d665eac45..f5038f4f0 100644
  prepare_task_switch(struct rq *rq, struct task_struct *prev,
  		    struct task_struct *next)
  {
-@@ -3413,6 +3413,8 @@ asmlinkage __visible void schedule_tail(struct task_struct *prev)
+@@ -3417,6 +3417,8 @@ asmlinkage __visible void schedule_tail(struct task_struct *prev)
  /*
   * context_switch - switch to the new MM and the new thread's register state.
   */
@@ -43,15 +43,14 @@ index d665eac45..f5038f4f0 100644
  static __always_inline struct rq *
  context_switch(struct rq *rq, struct task_struct *prev,
  	       struct task_struct *next, struct rq_flags *rf)
-@@ -3465,7 +3467,42 @@ context_switch(struct rq *rq, struct task_struct *prev,
+@@ -3469,7 +3471,40 @@ context_switch(struct rq *rq, struct task_struct *prev,
  	prepare_lock_switch(rq, next, rf);
  
  	/* Here we just switch the register state and the stack. */
 -	switch_to(prev, next, prev);
 +#ifdef CONFIG_X86_64
 +	__asm__("add %0,%%rsp\n\t"
-+		"pushq %1\n\t"
-+		"jmp __switch_to_asm"
++		"jmp *%1"
 +		:
 +		:"i"(STACKSIZE_MOD - STACKSIZE_VMLINUX), "r"(sched_springboard), "D"(prev), "S"(next)
 +		:"rbx","r12","r13","r14","r15"
@@ -74,8 +73,7 @@ index d665eac45..f5038f4f0 100644
 +		"stp x27,x28,[sp, #80]\n\t"
 +		"mov x0,%2\n\t"
 +		"mov x1,%3\n\t"
-+		"ldr x30,%1\n\t"
-+		"b __switch_to"
++		"br %1"
 +		:
 +		:"i"(STACKSIZE_SCHEDULE), "m"(sched_springboard),"r"(prev),"r"(next)
 +		:"x19","x20","x21","x22","x23","x24","x25",

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,13 +45,13 @@ cmd_find_sym = 			                                         \
 	fi
 
 CFLAGS_core.stub.o := -DMODULE -DSTACKSIZE_MOD=0
+CFLAGS_main.stub.o := -DMODULE_FRAME_POINTER=VMLINUX_FRAME_POINTER
 $(obj)/%.stub.o: $(src)/%.c FORCE
 	$(call cmd,force_checksrc)
 	$(call if_changed_rule,cc_o_c)
 
 GET_STACK_SIZE: $(obj)/core.stub.o
-	$(eval CFLAGS_core.o += -DSTACKSIZE_MOD=$(shell bash \
-		$(plugsched_tmpdir)/springboard_search.sh build $<))
+	$(eval ccflags-y += $(shell bash $(plugsched_tmpdir)/springboard_search.sh build $<))
 
 $(obj)/.globalize: $(src)/export_jump.h $(obj-stub) FORCE
 	$(cmd_find_sym)

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,10 @@
 #include "head_jump.h"
 #include "stack_check.h"
 
+#define CHECK_STACK_LAYOUT() \
+	BUILD_BUG_ON_MSG(MODULE_FRAME_POINTER != VMLINUX_FRAME_POINTER, \
+		"stack layout of __schedule can not match to it in vmlinux")
+
 #define MAX_CPU_NR		1024
 
 extern void __orig___schedule(bool);
@@ -580,6 +584,8 @@ static int register_plugsched_sysfs(void)
 static int __init sched_mod_init(void)
 {
 	int ret;
+
+	CHECK_STACK_LAYOUT();
 
 	printk("Hi, scheduler mod is installing!\n");
 	init_start = ktime_get();


### PR DESCRIPTION
See the commit bfa04fc96da3e4252419dd3f7d2088efa3cfed97 <src: jump to vmlinux's call instead of pushing our return addres>

This commit adapets the springboard of kernel 5.10.

Why I delete the modification of the attribute of perpare_task_switch function is that, the frame pointer of __schedule in vmlinux becames not optimized. We cannot decide whether the frame pointer is optimized or not in vmlinux. Therefore, fixed stack frame pointer of __schedule function in vmlinux is more friendly to us.