### PR TITLE
border: fix sched_class renaming failing on some kernels

### DIFF
--- a/boundary/extract.py
+++ b/boundary/extract.py
@@ -254,8 +254,8 @@ class Extraction(object):
         delete = re.compile('initcall|early_param|__init |__initdata |__setup')
         replace_list = [
             (re.compile(r'struct atomic_t'), r'atomic_t'),
-            (re.compile(r'(^const .*) ((stop|dl|rt|fair|idle)_sched_class)'),
-             r'\1 shadow_\2'),
+            (re.compile(r'^(?!extern ).*struct sched_class ((stop|dl|rt|fair|idle)_sched_class)'),
+             r'struct sched_class shadow_\1'),
         ]
 
         for (i, line) in enumerate(lines):


### PR DESCRIPTION
In some kernels, some sched_class variables are not defined as const. 
And we failed to match the pattern. So we use a more stable one instead.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>