### PR TITLE
border: exclude not-linked weak functions from tainted functions

### DIFF
--- a/boundary/analyze.py
+++ b/boundary/analyze.py
@@ -259,7 +259,7 @@ def func_class_arithmetics(fns):
 
     # Inflect outsider functions
     fns.inflect_cut = fns.border | fns.init | fns.sidecar
-    fns.insider = inflect(fns.initial_insider, edges) - fns.init
+    fns.insider = inflect(fns.initial_insider, edges) - fns.init - fns.fake_global
     fns.sched_outsider = (fns.mod_fns - fns.insider - fns.border) | fns.cb_opt
     fns.sched_outsider |= fns.fake_global & fns.mod_fns
     fns.outsider_opt = fns.sched_outsider - fns.in_vmlinux - fns.init


### PR DESCRIPTION
If weak symbols within the boundary are not linked into vmlinux, then they are classified as fake-global, because the real global symbols are the corresponding strong symbols that reside in other source files.

fake-global functions are added to scheduler-outsiders after inflection, so that their definitions can be removed. Also they should be removed from the insider set too.

This patch influences only confliction checking against kpatch.

Fixes: 259c48336f85("border: treat overriden weak symbols as outsiders")
Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>