### PR TITLE
config: fix panic when CPU hotplug on 5.10

### DIFF
--- a/configs/5.10/boundary.yaml
+++ b/configs/5.10/boundary.yaml
@@ -111,6 +111,8 @@ global_var:
     - normalized_sysctl_sched_latency
     - normalized_sysctl_sched_min_granularity
     - normalized_sysctl_sched_wakeup_granularity
+    - sched_domains_tmpmask
+    - sched_domains_tmpmask2
     force_private:
     - sysctl_sched_features
     - sched_feat_keys


### PR DESCRIPTION
Since commit ace8031099f9("sched/topology: Make local variables static"), sched_domains_tmpmask becomes local variable. And plugsched tags local variables as private variables. Besides, sched_domain is a component which is not covered by sched_rebuild technique. These two facts make sched_domains_tmpmask re-initialized to zero after loading the module.

However, sched_domains_tmpmask should be shared with the kernel because it contains running state information. Otherwise, when rebuilding the sched domain (e.g. when CPU hotplug), the kernel panics.

So put sched_domains_tmpmask (and sched_domains_tmpmask2) to extra public to fix this panic issue.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>