### PR TITLE
config: fix stack pivot, stack chk and springboard for 5.10 on aarch64

### DIFF
--- a/configs/5.10/dynamic_springboard.patch
+++ b/configs/5.10/dynamic_springboard.patch
@@ -59,7 +59,7 @@ index eee32739c..26ccde413 100644
 +		"mov x1,%3\n\t"
 +		"br %1"
 +		:
-+		:"i"(STACKSIZE_SCHEDULE), "m"(sched_springboard),"r"(prev),"r"(next)
++		:"i"(STACKSIZE_VMLINUX), "r"(sched_springboard),"r"(prev),"r"(next)
 +		:"x19","x20","x21","x22","x23","x24","x25",
 +		 "x26","x27","x28","x30","x0","x1"
 +	);


### PR DESCRIPTION
- Fix stack pivot typo from STACKSIZE_SCHEDULE to STACKSIZE_VMLINUX.
- Fix springboard bug by passing register instead of memory to br insn.
- Fix stack chk
  * Sometimes it jumps to 4 bytes before stack_chk_fail than right at it.
  * Sometimes there are less than 12 callee-saved registers.
  * When stack chk searching fails, error handling is not working.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>