### PR TITLE
contrib: add conflict check with plugbpf

### DIFF
--- a/module-contrib/hotfix_conflict_check
+++ b/module-contrib/hotfix_conflict_check
@@ -33,8 +33,8 @@ find /sys/kernel/kpatch/patches/*/functions -type d -not -path "*/functions" 2>/
 	echo "$func" >> $func_list_nosympos
 done
 
-# deal with kpatch 0.4 ABI, livepatch and plugsched
-for subdir in kpatch livepatch plugsched; do
+# deal with kpatch 0.4 ABI, livepatch, plugsched, and plugbpf
+for subdir in kpatch livepatch plugsched plugbpf; do
 	find /sys/kernel/$subdir/*/ -type d -path "*,[0-9]" 2>/dev/null | while read path ; do
 		# /sys/kernel/kpatch/kpatch_5135717/vmlinux/kernfs_find_ns,1 -> kernfs_find_ns,1
 		func_ver=`echo $path | awk -F / -e '{print $NF}'`


### PR DESCRIPTION
Plugbpf will be productized in future. It may work together with plugsched in some scenarios.
Add check for this to avoid conflicts.