### PR TITLE
border: update post_extract.patch of 3.10

### DIFF
--- a/configs/3.10/post_extract.patch
+++ b/configs/3.10/post_extract.patch
@@ -1,5 +1,5 @@
 diff --git a/kernel/sched/mod/Makefile b/kernel/sched/mod/Makefile
-index 2c617d7..5f78875 100644
+index 38dbf6d..31c6d91 100644
 --- a/kernel/sched/mod/Makefile
 +++ b/kernel/sched/mod/Makefile
 @@ -15,9 +15,9 @@ CFLAGS_core.o := $(PROFILING) -fno-omit-frame-pointer
@@ -15,7 +15,7 @@ index 2c617d7..5f78875 100644
  objs-$(CONFIG_SCHED_DEBUG) += debug.o
  
 diff --git a/kernel/sched/mod/core.c b/kernel/sched/mod/core.c
-index 933ec23..c15d604 100644
+index 6057509..dcf3e2f 100644
 --- a/kernel/sched/mod/core.c
 +++ b/kernel/sched/mod/core.c
 @@ -57,6 +57,9 @@
@@ -36,7 +36,7 @@ index 933ec23..c15d604 100644
  #include <trace/events/sched.h>
  
  #ifdef smp_mb__before_atomic
-@@ -7533,9 +7535,13 @@ void sched_cpu_deactivate(unsigned int cpu);
+@@ -7531,9 +7533,13 @@ void sched_cpu_deactivate(unsigned int cpu);
  #else
  #endif /* CONFIG_SMP */
  
@@ -51,20 +51,25 @@ index 933ec23..c15d604 100644
  		&& addr < (unsigned long)__sched_text_end);
  }
 diff --git a/kernel/sched/mod/main.c b/kernel/sched/mod/main.c
-index 4730740..5adc57a 100644
+index 8e08642..c1d1604 100644
 --- a/kernel/sched/mod/main.c
 +++ b/kernel/sched/mod/main.c
-@@ -12,6 +12,8 @@
+@@ -12,19 +12,30 @@
  #include <linux/sched/task.h>
  #include <linux/sysfs.h>
  #include <linux/version.h>
 +#include <linux/debugfs.h>
 +#include <linux/proc_fs.h>
  #include "sched.h"
+ #include "helper.h"
  #include "mempool.h"
  #include "head_jump.h"
-@@ -19,7 +21,20 @@
+ #include "stack_check.h"
  
+-#define CHECK_STACK_LAYOUT() \
+-	BUILD_BUG_ON_MSG(MODULE_FRAME_POINTER != VMLINUX_FRAME_POINTER, \
+-		"stack layout of __schedule can not match to it in vmlinux")
+-
  #define MAX_CPU_NR		1024
  
 -extern void __orig___schedule(bool);
@@ -85,7 +90,7 @@ index 4730740..5adc57a 100644
  int process_id[MAX_CPU_NR];
  atomic_t cpu_finished;
  atomic_t clear_finished;
-@@ -48,10 +63,9 @@ extern struct percpu_rw_semaphore cpuset_rwsem;
+@@ -53,10 +64,9 @@ extern struct percpu_rw_semaphore cpuset_rwsem;
  	percpu_up_write(&cpuset_rwsem)
  #endif
  
@@ -98,7 +103,7 @@ index 4730740..5adc57a 100644
  
  static struct dentry *sched_features_dir;
  static s64 stop_time;
-@@ -260,8 +274,25 @@ static int sync_sched_mod(void *func)
+@@ -265,8 +275,25 @@ static int sync_sched_mod(void *func)
  }
  
  #ifdef CONFIG_SCHED_DEBUG
@@ -125,7 +130,7 @@ index 4730740..5adc57a 100644
  
  static inline void install_sched_domain_sysctl(void)
  {
-@@ -269,7 +300,7 @@ static inline void install_sched_domain_sysctl(void)
+@@ -274,7 +301,7 @@ static inline void install_sched_domain_sysctl(void)
  	plugsched_cpuset_lock();
  
  	__orig_unregister_sched_domain_sysctl();
@@ -134,7 +139,7 @@ index 4730740..5adc57a 100644
  
  	plugsched_cpuset_unlock();
  	mutex_unlock(&cgroup_mutex);
-@@ -280,8 +311,7 @@ static inline void restore_sched_domain_sysctl(void)
+@@ -285,8 +312,7 @@ static inline void restore_sched_domain_sysctl(void)
  	mutex_lock(&cgroup_mutex);
  	plugsched_cpuset_lock();
  
@@ -144,7 +149,7 @@ index 4730740..5adc57a 100644
  	__orig_register_sched_domain_sysctl();
  
  	plugsched_cpuset_unlock();
-@@ -307,7 +337,7 @@ void install_sched_debugfs(void)
+@@ -312,7 +338,7 @@ void install_sched_debugfs(void)
  }
  
  extern struct file_operations __orig_sched_feat_fops;
@@ -153,7 +158,7 @@ index 4730740..5adc57a 100644
  
  void restore_sched_debugfs(void)
  {
-@@ -320,7 +350,7 @@ int install_sched_debug_procfs(void)
+@@ -325,7 +351,7 @@ int install_sched_debug_procfs(void)
  {
  	remove_proc_entry("sched_debug", NULL);
  
@@ -162,7 +167,7 @@ index 4730740..5adc57a 100644
  		return -ENOMEM;
  
  	return 0;
-@@ -330,7 +360,7 @@ int restore_sched_debug_procfs(void)
+@@ -335,7 +361,7 @@ int restore_sched_debug_procfs(void)
  {
  	remove_proc_entry("sched_debug", NULL);
  
@@ -171,7 +176,7 @@ index 4730740..5adc57a 100644
  		return -ENOMEM;
  
  	return 0;
-@@ -338,14 +368,14 @@ int restore_sched_debug_procfs(void)
+@@ -343,14 +369,14 @@ int restore_sched_debug_procfs(void)
  #endif
  
  #ifdef CONFIG_SCHEDSTATS
@@ -188,7 +193,7 @@ index 4730740..5adc57a 100644
  		return -ENOMEM;
  
  	return 0;
-@@ -355,7 +385,7 @@ int restore_proc_schedstat(void)
+@@ -360,7 +386,7 @@ int restore_proc_schedstat(void)
  {
  	remove_proc_entry("schedstat", NULL);
  
@@ -197,20 +202,29 @@ index 4730740..5adc57a 100644
  		return -ENOMEM;
  
  	return 0;
+@@ -586,8 +612,6 @@ static int __init sched_mod_init(void)
+ {
+ 	int ret;
+ 
+-	CHECK_STACK_LAYOUT();
+-
+ 	printk("Hi, scheduler mod is installing!\n");
+ 	init_start = ktime_get();
+ 
 diff --git a/kernel/sched/mod/sched_rebuild.c b/kernel/sched/mod/sched_rebuild.c
-index 6e8a4c7..94889e9 100644
+index 219dd29..fbbcad0 100644
 --- a/kernel/sched/mod/sched_rebuild.c
 +++ b/kernel/sched/mod/sched_rebuild.c
-@@ -6,8 +6,6 @@
- #include <linux/sched.h>
+@@ -7,8 +7,6 @@
  #include "sched.h"
+ #include "helper.h"
  
 -extern void __orig_set_rq_offline(struct rq*);
 -extern void __orig_set_rq_online(struct rq*);
  extern unsigned int process_id[];
  
  extern struct sched_class __orig_stop_sched_class;
-@@ -40,6 +38,40 @@ struct sched_class *mod_class[] = {
+@@ -41,6 +39,40 @@ struct sched_class *mod_class[] = {
  #define NR_SCHED_CLASS 5
  struct sched_class bak_class[NR_SCHED_CLASS];
  
@@ -249,9 +263,9 @@ index 6e8a4c7..94889e9 100644
 +}
 +/* DON'T MODIFY INLINE EXTERNAL FUNCTION __orig_set_rq_offline */
  
- static inline void do_write_cr0(unsigned long val)
+ void switch_sched_class(bool mod)
  {
-@@ -70,11 +102,11 @@ void clear_sched_state(bool mod)
+@@ -67,11 +99,11 @@ void clear_sched_state(bool mod)
  {
  	struct task_struct *g, *p;
  	struct rq *rq = this_rq();
@@ -265,7 +279,7 @@ index 6e8a4c7..94889e9 100644
  	} else {
  		__orig_set_rq_offline(rq);
  	}
-@@ -86,9 +118,6 @@ void clear_sched_state(bool mod)
+@@ -83,9 +115,6 @@ void clear_sched_state(bool mod)
  		if (p == rq->stop)
  			continue;
  
@@ -275,7 +289,7 @@ index 6e8a4c7..94889e9 100644
  		if (task_on_rq_queued(p))
  			p->sched_class->dequeue_task(rq, p, queue_flags);
  	}
-@@ -100,12 +129,12 @@ void rebuild_sched_state(bool mod)
+@@ -97,12 +126,12 @@ void rebuild_sched_state(bool mod)
  	struct task_struct *g, *p;
  	struct task_group *tg;
  	struct rq *rq = this_rq();
@@ -290,7 +304,7 @@ index 6e8a4c7..94889e9 100644
  	} else {
  		__orig_set_rq_online(rq);
  	}
-@@ -130,12 +159,12 @@ void rebuild_sched_state(bool mod)
+@@ -127,12 +156,12 @@ void rebuild_sched_state(bool mod)
  		if (tg == &root_task_group)
  			continue;
  
@@ -305,3 +319,35 @@ index 6e8a4c7..94889e9 100644
  			hrtimer_restart(&tg->rt_bandwidth.rt_period_timer);
  #endif
  	}
+diff --git a/kernel/sched/mod/stack_check.h b/kernel/sched/mod/stack_check.h
+index f83c463..2517230 100644
+--- a/kernel/sched/mod/stack_check.h
++++ b/kernel/sched/mod/stack_check.h
+@@ -24,7 +24,6 @@ static void stack_check_init(void)
+ 	#undef EXPORT_PLUGSCHED
+ 	#undef EXPORT_CALLBACK
+ 
+-	vm_func_size[NR___schedule] = 0;
+ 	addr_sort(vm_func_addr, vm_func_size, NR_INTERFACE_FN);
+ 
+ 	#define EXPORT_CALLBACK(fn, ...) 				\
+@@ -41,7 +40,6 @@ static void stack_check_init(void)
+ 	#undef EXPORT_PLUGSCHED
+ 	#undef EXPORT_CALLBACK
+ 
+-	mod_func_size[NR___schedule] = 0;
+ 	addr_sort(mod_func_addr, mod_func_size, NR_INTERFACE_FN);
+ }
+ 
+@@ -143,11 +141,7 @@ static unsigned int get_stack_trace(struct task_struct *tsk,
+         trace.max_entries = MAX_STACK_ENTRIES;
+         trace.entries = store;
+ 
+-	if (!try_get_task_stack(tsk))
+-		return 0;
+-
+ 	save_stack(&trace, tsk);
+-	put_task_stack(tsk);
+ 	return trace.nr_entries;
+ }
+ #endif


### PR DESCRIPTION
Update the following two points:

1. Update the stack check function to match the kernel 3.10.
2. Remove the assertion of stack layout because the __scheduler has been removed outside.

Signed-off-by: Erwei Deng <erwei@linux.alibaba.com>