### PR TITLE
src: clean and rebuild the dying tasks

### DIFF
--- a/src/sched_rebuild.c
+++ b/src/sched_rebuild.c
@@ -86,6 +86,10 @@ void clear_sched_state(bool mod)
 	int cpu = smp_processor_id();
 
 	rq_lock(rq, &rf);
+
+	/* To avoid SCHED_WARN_ON(rq->clock_update_flags < RQCF_ACT_SKIP) */
+	rq->clock_update_flags = RQCF_UPDATED;
+
 	if (mod) {
 		set_rq_offline(rq);
 	} else {
@@ -98,9 +102,6 @@ void clear_sched_state(bool mod)
 
 		if (p == rq->stop)
 			continue;
-
-		/* To avoid SCHED_WARN_ON(rq->clock_update_flags < RQCF_ACT_SKIP) */
-		rq->clock_update_flags = RQCF_UPDATED;
 
 		if (task_on_rq_queued(p))
 			p->sched_class->dequeue_task(rq, p, queue_flags);

--- a/src/sched_rebuild.c
+++ b/src/sched_rebuild.c
@@ -4,6 +4,7 @@
  */
 
 #include <linux/sched.h>
+#include <linux/version.h>
 #include "sched.h"
 #include "helper.h"
 
@@ -38,9 +39,22 @@ struct sched_class *mod_class[] = {
 	&shadow_idle_sched_class,
 };
 
+DEFINE_PER_CPU(struct list_head, dying_task_list);
+
 #define NR_SCHED_CLASS 5
 struct sched_class bak_class[NR_SCHED_CLASS];
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0)
+
+extern struct task_struct __orig_fake_task;
+
+#define pick_next_task_rq(class, rf) \
+	(class)->pick_next_task(rq, &__orig_fake_task, &(rf))
+
+#else
+#define pick_next_task_rq(class, rf) \
+	(class)->pick_next_task(rq)
+#endif
 
 void switch_sched_class(bool mod)
 {
@@ -67,9 +81,11 @@ void clear_sched_state(bool mod)
 {
 	struct task_struct *g, *p;
 	struct rq *rq = this_rq();
+	struct rq_flags rf;
 	int queue_flags = DEQUEUE_SAVE | DEQUEUE_MOVE | DEQUEUE_NOCLOCK;
+	int cpu = smp_processor_id();
 
-	raw_spin_lock(&rq->lock);
+	rq_lock(rq, &rf);
 	if (mod) {
 		set_rq_offline(rq);
 	} else {
@@ -89,7 +105,29 @@ void clear_sched_state(bool mod)
 		if (task_on_rq_queued(p))
 			p->sched_class->dequeue_task(rq, p, queue_flags);
 	}
-	raw_spin_unlock(&rq->lock);
+
+	INIT_LIST_HEAD(&per_cpu(dying_task_list, cpu));
+
+	/* This logic comes from sched_cpu_dying to deal with dying tasks. */
+	for (;;) {
+		const struct sched_class *class;
+		struct task_struct *next;
+
+		/* Now, just the stopper task is running. */
+		if (rq->nr_running == 1)
+			break;
+
+		for_each_class(class) {
+			next = pick_next_task_rq(class, rf);
+			if (next) {
+				next->sched_class->put_prev_task(rq, next);
+				next->sched_class->dequeue_task(rq, p, queue_flags);
+				list_add_tail_rcu(&p->tasks, &per_cpu(dying_task_list, cpu));
+				break;
+			}
+		}
+	}
+	rq_unlock(rq, &rf);
 }
 
 void rebuild_sched_state(bool mod)
@@ -97,10 +135,17 @@ void rebuild_sched_state(bool mod)
 	struct task_struct *g, *p;
 	struct task_group *tg;
 	struct rq *rq = this_rq();
+	struct rq_flags rf;
 	int queue_flags = ENQUEUE_RESTORE | ENQUEUE_MOVE | ENQUEUE_NOCLOCK;
 	int cpu = smp_processor_id();
 
-	raw_spin_lock(&rq->lock);
+	rq_lock(rq, &rf);
+
+	list_for_each_entry_rcu(p, &per_cpu(dying_task_list, cpu), tasks) {
+		p->sched_class->enqueue_task(rq, p, queue_flags);
+		list_del_init(&p->tasks);
+	}
+
 	if (mod) {
 		set_rq_online(rq);
 	} else {
@@ -117,7 +162,7 @@ void rebuild_sched_state(bool mod)
 		if (task_on_rq_queued(p))
 			p->sched_class->enqueue_task(rq, p, queue_flags);
 	}
-	raw_spin_unlock(&rq->lock);
+	rq_unlock(rq, &rf);
 
 	if (process_id[cpu])
 		return;


### PR DESCRIPTION
When a task goes to dying, there have a gap between removing from init_task list and releasing the task. In this case, we cannot find these tasks from init_task list, so that the rebuilder cannot deal with them including allocation and release memory.

The sched_cpu_dying gives us an idea that is using the pick_next_task to find these tasks. So it is safe.

Co-developed-by: Cruz Zhao <CruzZhao@linux.alibaba.com>
Signed-off-by: Erwei Deng <erwei@linux.alibaba.com>