### PR TITLE
border: fix the logic of rebuilding dying task for 3.10

### DIFF
--- a/configs/3.10/post_extract.patch
+++ b/configs/3.10/post_extract.patch
@@ -15,7 +15,7 @@ index 38dbf6d..31c6d91 100644
  objs-$(CONFIG_SCHED_DEBUG) += debug.o
  
 diff --git a/kernel/sched/mod/core.c b/kernel/sched/mod/core.c
-index 6057509..dcf3e2f 100644
+index e5236bd..1970dcf 100644
 --- a/kernel/sched/mod/core.c
 +++ b/kernel/sched/mod/core.c
 @@ -57,6 +57,9 @@
@@ -36,7 +36,7 @@ index 6057509..dcf3e2f 100644
  #include <trace/events/sched.h>
  
  #ifdef smp_mb__before_atomic
-@@ -7531,9 +7533,13 @@ void sched_cpu_deactivate(unsigned int cpu);
+@@ -7530,9 +7532,13 @@ void sched_cpu_deactivate(unsigned int cpu);
  #else
  #endif /* CONFIG_SMP */
  
@@ -212,10 +212,10 @@ index 8e08642..c1d1604 100644
  	init_start = ktime_get();
  
 diff --git a/kernel/sched/mod/sched_rebuild.c b/kernel/sched/mod/sched_rebuild.c
-index 219dd29..fbbcad0 100644
+index 20e8f4c..d2b3343 100644
 --- a/kernel/sched/mod/sched_rebuild.c
 +++ b/kernel/sched/mod/sched_rebuild.c
-@@ -7,8 +7,6 @@
+@@ -8,8 +8,6 @@
  #include "sched.h"
  #include "helper.h"
  
@@ -224,7 +224,7 @@ index 219dd29..fbbcad0 100644
  extern unsigned int process_id[];
  
  extern struct sched_class __orig_stop_sched_class;
-@@ -41,6 +39,40 @@ struct sched_class *mod_class[] = {
+@@ -44,12 +42,47 @@ DEFINE_PER_CPU(struct list_head, dying_task_list);
  #define NR_SCHED_CLASS 5
  struct sched_class bak_class[NR_SCHED_CLASS];
  
@@ -262,49 +262,83 @@ index 219dd29..fbbcad0 100644
 +	}
 +}
 +/* DON'T MODIFY INLINE EXTERNAL FUNCTION __orig_set_rq_offline */
++
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 3, 0)
  
- void switch_sched_class(bool mod)
- {
-@@ -67,11 +99,11 @@ void clear_sched_state(bool mod)
+ extern struct task_struct __orig_fake_task;
+ 
+ #define pick_next_task_rq(class, rf) \
+-	(class)->pick_next_task(rq, &__orig_fake_task, &(rf))
++	(class)->pick_next_task(rq, &__orig_fake_task)
+ 
+ #else
+ #define pick_next_task_rq(class, rf) \
+@@ -83,15 +116,14 @@ void clear_sched_state(bool mod)
  {
  	struct task_struct *g, *p;
  	struct rq *rq = this_rq();
+-	struct rq_flags rf;
 -	int queue_flags = DEQUEUE_SAVE | DEQUEUE_MOVE | DEQUEUE_NOCLOCK;
 +	int queue_flags = DEQUEUE_SAVE;
+ 	int cpu = smp_processor_id();
  
- 	raw_spin_lock(&rq->lock);
+-	rq_lock(rq, &rf);
++	raw_spin_lock(&rq->lock);
+ 
  	if (mod) {
+ 		update_rq_clock(rq);
 -		set_rq_offline(rq);
 +		__mod_set_rq_offline(rq);
  	} else {
+ 		__orig_update_rq_clock(rq);
  		__orig_set_rq_offline(rq);
- 	}
-@@ -83,9 +115,6 @@ void clear_sched_state(bool mod)
- 		if (p == rq->stop)
- 			continue;
+@@ -120,7 +152,7 @@ void clear_sched_state(bool mod)
+ 			break;
  
--		/* To avoid SCHED_WARN_ON(rq->clock_update_flags < RQCF_ACT_SKIP) */
--		rq->clock_update_flags = RQCF_UPDATED;
--
- 		if (task_on_rq_queued(p))
- 			p->sched_class->dequeue_task(rq, p, queue_flags);
+ 		for_each_class(class) {
+-			next = pick_next_task_rq(class, rf);
++			next = pick_next_task_rq(class, NULL);
+ 			if (next) {
+ 				next->sched_class->put_prev_task(rq, next);
+ 				next->sched_class->dequeue_task(rq, p, queue_flags);
+@@ -129,7 +161,7 @@ void clear_sched_state(bool mod)
+ 			}
+ 		}
  	}
-@@ -97,12 +126,12 @@ void rebuild_sched_state(bool mod)
+-	rq_unlock(rq, &rf);
++	raw_spin_unlock(&rq->lock);
+ }
+ 
+ void rebuild_sched_state(bool mod)
+@@ -137,15 +169,14 @@ void rebuild_sched_state(bool mod)
  	struct task_struct *g, *p;
  	struct task_group *tg;
  	struct rq *rq = this_rq();
+-	struct rq_flags rf;
 -	int queue_flags = ENQUEUE_RESTORE | ENQUEUE_MOVE | ENQUEUE_NOCLOCK;
 +	int queue_flags = ENQUEUE_RESTORE;
  	int cpu = smp_processor_id();
  
- 	raw_spin_lock(&rq->lock);
+-	rq_lock(rq, &rf);
++	raw_spin_lock(&rq->lock);
+ 
  	if (mod) {
+ 		update_rq_clock(rq);
 -		set_rq_online(rq);
 +		__mod_set_rq_online(rq);
  	} else {
+ 		__orig_update_rq_clock(rq);
  		__orig_set_rq_online(rq);
+@@ -166,7 +197,7 @@ void rebuild_sched_state(bool mod)
+ 		p->sched_class->enqueue_task(rq, p, queue_flags);
+ 		list_del_init(&p->tasks);
  	}
-@@ -127,12 +156,12 @@ void rebuild_sched_state(bool mod)
+-	rq_unlock(rq, &rf);
++	raw_spin_unlock(&rq->lock);
+ 
+ 	if (process_id[cpu])
+ 		return;
+@@ -176,12 +207,12 @@ void rebuild_sched_state(bool mod)
  		if (tg == &root_task_group)
  			continue;
  


### PR DESCRIPTION
Because the kernel 3.10 does not have the rq_flags and clock_update_flags, it is necessary to adjust the rebuilding dying task logic.