### PR TITLE
border: add wake_up_idle_ht to interface for 5.10

### DIFF
--- a/configs/5.10/boundary.yaml
+++ b/configs/5.10/boundary.yaml
@@ -31,6 +31,7 @@ interface_prefix:
 function:
     interface:
         - yield_to
+        - wake_up_idle_ht
         - send_call_function_single_ipi
         - do_set_cpus_allowed
         - set_user_nice


### PR DESCRIPTION
After boundary analysis, wake_up_idle_ht is a insider function. But it is called by the bottom of __schedule and this function of vmlinux will be called too. So it should be a interface function.