### PR TITLE
contrib: fix unmatching version of gcc and gcc-python-plugin in Docke…

### DIFF
--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 From openanolis/anolisos:8.6-x86_64
 
+RUN echo 8.6 > /etc/yum/vars/releasever
+
 RUN yum install python3 python3-devel python3-lxml gcc gcc-c++ wget libyaml-devel -y && \
     yum install python3-pip python3-Cython -y
 RUN pip3 install --upgrade setuptools && \


### PR DESCRIPTION
…rfile

Although we build the docker image based on AnolisOS 8.6, softwares are automatically upgraded to the latest minor version of AnolisOS 8. gcc-python-plugin hasn't bumped its version to match gcc. So in order to get it work, we explicitly install softwares of AnolisOS 8.6 on this image.