### PR TITLE
src: use the right rule to reference symbols in module

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,7 +38,7 @@ cmd_find_sym = 			                                         \
 	readelf -sW $(obj-stub) | $(search_und) | tee $(und-file) >> $@; \
 	count1=$$(cat $(und-file) | wc -l);                              \
 	count2=$$(readelf -sW $(obj-stub) | grep -w -f $(und-file) |     \
-		  grep -v '\.' | wc -l);                                 \
+		  grep -v '\.' | grep -v UND | wc -l);                   \
 	if [ "$$count1" != "$$count2" ]; then                            \
 		echo -e '\033[31m'$(error_msg)'\033[0m';                 \
 		exit 1;                                                  \

--- a/src/main.c
+++ b/src/main.c
@@ -268,13 +268,16 @@ static int sync_sched_mod(void *func)
 extern void __orig_register_sched_domain_sysctl(void);
 extern void __orig_unregister_sched_domain_sysctl(void);
 
+extern void __mod_register_sched_domain_sysctl(void);
+extern void __mod_unregister_sched_domain_sysctl(void);
+
 static inline void install_sched_domain_sysctl(void)
 {
 	mutex_lock(&cgroup_mutex);
 	plugsched_cpuset_lock();
 
 	__orig_unregister_sched_domain_sysctl();
-	register_sched_domain_sysctl();
+	__mod_register_sched_domain_sysctl();
 
 	plugsched_cpuset_unlock();
 	mutex_unlock(&cgroup_mutex);
@@ -285,7 +288,7 @@ static inline void restore_sched_domain_sysctl(void)
 	mutex_lock(&cgroup_mutex);
 	plugsched_cpuset_lock();
 
-	unregister_sched_domain_sysctl();
+	__mod_unregister_sched_domain_sysctl();
 	cpumask_copy(sd_sysctl_cpus, cpu_possible_mask);
 	__orig_register_sched_domain_sysctl();
 

--- a/src/sched_rebuild.c
+++ b/src/sched_rebuild.c
@@ -10,6 +10,12 @@
 
 extern void __orig_set_rq_offline(struct rq*);
 extern void __orig_set_rq_online(struct rq*);
+extern void __orig_update_rq_clock(struct rq *rq);
+
+extern void __mod_set_rq_offline(struct rq*);
+extern void __mod_set_rq_online(struct rq*);
+extern void __mod_update_rq_clock(struct rq *rq);
+
 extern unsigned int process_id[];
 
 extern struct sched_class __orig_stop_sched_class;
@@ -77,8 +83,6 @@ void switch_sched_class(bool mod)
 	}
 }
 
-extern void __orig_update_rq_clock(struct rq *rq);
-
 void clear_sched_state(bool mod)
 {
 	struct task_struct *g, *p;
@@ -90,8 +94,8 @@ void clear_sched_state(bool mod)
 	rq_lock(rq, &rf);
 
 	if (mod) {
-		update_rq_clock(rq);
-		set_rq_offline(rq);
+		__mod_update_rq_clock(rq);
+		__mod_set_rq_offline(rq);
 	} else {
 		__orig_update_rq_clock(rq);
 		__orig_set_rq_offline(rq);
@@ -144,8 +148,8 @@ void rebuild_sched_state(bool mod)
 	rq_lock(rq, &rf);
 
 	if (mod) {
-		update_rq_clock(rq);
-		set_rq_online(rq);
+		__mod_update_rq_clock(rq);
+		__mod_set_rq_online(rq);
 	} else {
 		__orig_update_rq_clock(rq);
 		__orig_set_rq_online(rq);


### PR DESCRIPTION
For the symbol referenced, we have a rule:
If we reference module's symbols, we need to add the __mod_ prefix to the symbol, and if reference vmlinux's symbols, we need to add __orig_ prefix to the symbol.

In main.c and sched_rebuild.c, some symbol references do not follow the above rule. So I fixed them.