### PR TITLE
Set the default value for the any new added configs.

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -148,6 +148,7 @@ class Plugsched(object):
 
     def extract(self):
         logging.info('Extracting scheduler module objs: %s', ' '.join(self.mod_objs))
+        self.mod_sh.make('olddefconfig')
         self.make(stage = 'collect', plugsched_tmpdir = self.tmp_dir, plugsched_modpath = self.mod_path)
         self.make(stage = 'analyze', plugsched_tmpdir = self.tmp_dir, plugsched_modpath = self.mod_path)
         self.make(stage = 'extract', plugsched_tmpdir = self.tmp_dir, plugsched_modpath = self.mod_path,


### PR DESCRIPTION
The olddefconfig target can set the default value for any new configuration options that have been added to .config.

For the .config, it may add some new config for different compilation environment just like the CONFIG_GCC_PLUGIN, and if you do not specify a build target, the kbuild system will ask the user for the value of this configuration.

So I use the olddefconfig target to set these new configs to default value.