### PR TITLE
Standardized spec of scheduler package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ After the development, the scheduler with loading/unloading and other related co
 3. Unified management of scheduler hotfixes to avoid conflicts caused by multiple hotfixes.
 
 ## Quick Start
-Plugsched currently supports Anolis OS 7.9 ANCK by default, and other OS need to adjust the [boundary configurations](./docs/Support-various-Linux-distros.md). In order to reduce the complexity of building a running environment, we provide container images and Dockerfiles, and developers do not need to build a development environment by themselves. For convenience, we purchased an Alibaba Cloud ECS (64CPU + 128GB) and installed the Anolis OS 7.9 ANCK. We will live update the kernel scheduler.
+Plugsched currently supports Anolis OS 8.6 ANCK by default, and other OS need to adjust the [boundary configurations](./docs/Support-various-Linux-distros.md). In order to reduce the complexity of building a running environment, we provide container images and Dockerfiles, and developers do not need to build a development environment by themselves. For convenience, we purchased an Alibaba Cloud ECS (64CPU + 128GB) and installed the Anolis OS 8.6 ANCK. We will live update the kernel scheduler.
 
 1. Log into the cloud server, and install some necessary basic software packages.
 ```shell
@@ -120,7 +120,7 @@ index 4c40fac..8d1eafd 100644
 7. Copy the scheduler rpm to the host, exit the container, and view the current sched_features.
 ```text
 # uname_r=$(uname -r)
-# cp /usr/local/lib/plugsched/rpmbuild/RPMS/x86_64/scheduler-xxx-${uname_r%.*}.yyy.x86_64.rpm /tmp/work/scheduler-xxx.rpm
+# cp /tmp/work/scheduler/working/rpmbuild/RPMS/x86_64/scheduler-xxx-${uname_r%.*}.yyy.x86_64.rpm /tmp/work/scheduler-xxx.rpm
 # exit
 exit
 # cat /sys/kernel/debug/sched_features

--- a/README_zh.md
+++ b/README_zh.md
@@ -53,7 +53,7 @@ plugsched 是 Linux 内核调度器子系统热升级的 SDK，它可以实现�
 3. 统一管理调度器热补丁，避免多个热补丁之间的冲突而引发故障；
 
 ## Quick Start
-目前，plugsched 默认支持 Anolis OS 7.9 ANCK 系统发行版，其它系统需要[调整边界配置](./docs/Support-various-Linux-distros.md)。为了减轻搭建运行环境的复杂度，我们提供了的容器镜像和 Dockerfile，开发人员不需要自己去搭建开发环境。为了方便演示，这里购买了一台阿里云 ECS（64CPU + 128GB），并安装 Anolis OS 7.9 ANCK 系统发行版，我们将会对内核调度器进行热升级。
+目前，plugsched 默认支持 Anolis OS 8.6 ANCK 系统发行版，其它系统需要[调整边界配置](./docs/Support-various-Linux-distros.md)。为了减轻搭建运行环境的复杂度，我们提供了的容器镜像和 Dockerfile，开发人员不需要自己去搭建开发环境。为了方便演示，这里购买了一台阿里云 ECS（64CPU + 128GB），并安装 Anolis OS 8.6 ANCK 系统发行版，我们将会对内核调度器进行热升级。
 
 1. 登陆云服务器后，先安装一些必要的基础软件包：
 ```shell
@@ -120,7 +120,7 @@ index 4c40fac..8d1eafd 100644
 7. 将生成的 rpm 包拷贝到宿主机，退出容器，查看当前 sched_features：
 ```text
 # uname_r=$(uname -r)
-# cp /usr/local/lib/plugsched/rpmbuild/RPMS/x86_64/scheduler-xxx-${uname_r%.*}.yyy.x86_64.rpm /tmp/work/scheduler-xxx.rpm
+# cp /tmp/work/scheduler/working/rpmbuild/RPMS/x86_64/scheduler-xxx-${uname_r%.*}.yyy.x86_64.rpm /tmp/work/scheduler-xxx.rpm
 # exit
 exit
 # cat /sys/kernel/debug/sched_features

--- a/tests/build_case
+++ b/tests/build_case
@@ -9,6 +9,6 @@ podman cp $1/patch.diff plugsched:/root/patch
 podman exec plugsched patch -f -p1 -i patch
 podman exec plugsched plugsched-cli build scheduler
 podman exec plugsched patch -f -p1 -i patch -R
-podman exec plugsched ls /usr/local/lib/plugsched/rpmbuild/RPMS/$(uname -i)/
-podman exec plugsched bash -c "cp /usr/local/lib/plugsched/rpmbuild/RPMS/$(uname -i)/scheduler-xxx-*.rpm /root"
+podman exec plugsched ls /root/scheduler/working/rpmbuild/RPMS/$(uname -i)/
+podman exec plugsched bash -c "cp /root/scheduler/working/rpmbuild/RPMS/$(uname -i)/scheduler-xxx-*.rpm /root"
 


### PR DESCRIPTION
The previous packaging process was very non-standard. First of all, copying external files during the rpmbuild prep stage was non-standard. The main work of the prep stage should be to extract the tar package and apply patches. Therefore, I moved all the externally copied files to the working directory.

Secondly, there were many external directories defined in the cli build command, which is also non-standard. All files used in the packaging process should be in the BUILD directory. Therefore, I deleted all the defined macros and directly modified the _builddir build directory, so that the rpmbuild build phase can directly enter the scheduler working directory for execution.

Lastly, I modified the location of the RPM package. It was not a good idea to place the RPM package in the plugsched installation directory, so I put it in the scheduler working directory instead.