### PR TITLE
src: fix the bug that tasks enqueue between clear_sched_state() and rebuild_sched_state()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -178,8 +178,10 @@ static int __sync_sched_install(void *arg)
 		return error;
 	}
 
-	if (is_first_process())
+	if (is_first_process()) {
+		sched_alloc_extrapad();
 		stop_time_p1 = ktime_get();
+	}
 
 	clear_sched_state(false);
 	atomic_dec(&clear_finished);
@@ -190,7 +192,6 @@ static int __sync_sched_install(void *arg)
 		switch_sched_class(true);
 		JUMP_OPERATION(install);
 		disable_stack_protector();
-		sched_alloc_extrapad();
 		reset_balance_callback();
 	}
 
@@ -238,15 +239,16 @@ static int __sync_sched_restore(void *arg)
 		switch_sched_class(false);
 		JUMP_OPERATION(remove);
 		reset_balance_callback();
-		sched_free_extrapad();
 	}
 
 	atomic_dec(&redirect_finished);
 	atomic_cond_read_relaxed(&redirect_finished, !VAL);
 	rebuild_sched_state(false);
 
-	if (is_first_process())
+	if (is_first_process()) {
+		sched_free_extrapad();
 		stop_time_p2 = ktime_get();
+	}
 
 	return 0;
 }


### PR DESCRIPTION
sched_free_extrapad() is called between clear_sched_state() and rebuild_sched_state() in function __sync_sched_restore(). In function sched_free_extrapad(), free_percpu() may be called, which will result in queue_work_on() called, and a kwork will enqueue, between clear_sched_state() and rebuild_sched_state(), and it will enqueue again in function clear_sched_state(). In this case, cfs->h_nr_running will be wrong.

To fix this bug, we call sched_free_extrapad() later, after rebuild_sched_state().

Reported-by: Cruz Zhao <CruzZhao@linux.alibaba.com>